### PR TITLE
Metrics prefix change - 1.10.x

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -11,7 +11,7 @@ On-demand RabbitMQ for PCF components generate many of the [same metrics](./moni
 
 [//]: # (, but with the prefix `p.rabbitmq` instead of `p-rabbitmq`.)
 
-<p class="note"><strong>Note</strong>: As of v1.8.2, on-demand RabbitMQ for PCF emits metrics prefixed with <code>p-rabbitmq</code>. In future releases they will be be prefixed with <code>p.rabbitmq</code> (with a dot), to distinguish them from pre-provisioned service metrics. This is a <a href="./releases.html#18x">known issue</a>.</p>
+<p class="note"><strong>Note</strong>: Metrics are prefixed with <code>p.rabbitmq</code> (with a dot), to distinguish them from pre-provisioned service metrics.
 
 See [Logging and Metrics](http://docs.pivotal.io/pivotalcf/loggregator/index.html) for general information about logging and metrics in PCF.
 
@@ -87,7 +87,7 @@ This interval is a configuration option on the RabbitMQ tile (**Settings** > **R
 Metrics are long, single lines of text that follow the format:
 
 ```mac
-origin:"p-rabbitmq" eventType:ValueMetric timestamp:1441188462382091652 deployment:"cf-rabbitmq" job:"cf-rabbitmq-node" index:"0" ip:"10.244.3.46" valueMetric: < name:"/p-rabbitmq/rabbitmq/system/memory" value:1024 unit:"MB">
+origin:"p.rabbitmq" eventType:ValueMetric timestamp:1441188462382091652 deployment:"cf-rabbitmq" job:"cf-rabbitmq-node" index:"0" ip:"10.244.3.46" valueMetric: < name:"/p.rabbitmq/rabbitmq/system/memory" value:1024 unit:"MB">
 ```
 
 ### <a id="partition-indicator"></a>Partition Indicator
@@ -100,7 +100,7 @@ indication that that node might be in a partition.
 An example of that metrics is:
 
 ```mac
-origin:"p-rabbitmq" eventType:ValueMetric timestamp:1441188462382091652 deployment:"cf-rabbitmq" job:"cf-rabbitmq-node" index:"0" ip:"10.244.3.46" valueMetric: < name:"/p-rabbitmq/rabbitmq/erlang/reachable_nodes" value:3 unit:"count">
+origin:"p.rabbitmq" eventType:ValueMetric timestamp:1441188462382091652 deployment:"cf-rabbitmq" job:"cf-rabbitmq-node" index:"0" ip:"10.244.3.46" valueMetric: < name:"/p.rabbitmq/rabbitmq/erlang/reachable_nodes" value:3 unit:"count">
 ```
 
 Monitors can be created to emit alerts in case a cluster seems to be in a
@@ -133,7 +133,7 @@ Key RabbitMQ for PCF components periodically emit heartbeat metrics: the RabbitM
 #### <a id="broker-heartbeat"></a> Service Broker Heartbeat
 
 <table>
-   <tr><th colspan="2" style="text-align: center;"><br> p-rabbitmq.service_broker.heartbeat<br><br></th></tr>
+   <tr><th colspan="2" style="text-align: center;"><br> p.rabbitmq/service_broker/heartbeat<br><br></th></tr>
    <tr>
       <th width="25%">Description</th>
       <td>RabbitMQ Service Broker <code>is alive</code> poll, which indicates if the component is available and able to respond to requests.<br><br>
@@ -164,7 +164,7 @@ Key RabbitMQ for PCF components periodically emit heartbeat metrics: the RabbitM
 #### <a id="server-heartbeat"></a> Server Heartbeat
 
 <table>
-   <tr><th colspan="2" style="text-align: center;"><br> p-rabbitmq.rabbitmq.heartbeat<br><br></th></tr>
+   <tr><th colspan="2" style="text-align: center;"><br> p.rabbitmq/rabbitmq/heartbeat<br><br></th></tr>
    <tr>
       <th width="25%">Description</th>
       <td>RabbitMQ Server <code>is alive</code> poll, which indicates if the component is available and 
@@ -201,7 +201,7 @@ The following KPIs from the RabbitMQ server component:
 #### <a id="file-descriptors"></a> File Descriptors
 
 <table>
-   <tr><th colspan="2" style="text-align: center;"><br> p-rabbitmq.rabbitmq.system.file_descriptors<br><br></th></tr>
+   <tr><th colspan="2" style="text-align: center;"><br> p.rabbitmq/rabbitmq/system/file_descriptors<br><br></th></tr>
    <tr>
       <th width="25%">Description</th>
       <td>File descriptors consumed.<br><br>
@@ -233,7 +233,7 @@ The following KPIs from the RabbitMQ server component:
 #### <a id="erlang-processes"></a> Erlang Processes
 
 <table>
-   <tr><th colspan="2" style="text-align: center;"><br> p-rabbitmq.rabbitmq.system.erlang_processes<br><br></th></tr>
+   <tr><th colspan="2" style="text-align: center;"><br> p.rabbitmq/rabbitmq/system/erlang_processes<br><br></th></tr>
    <tr>
       <th width="25%">Description</th>
       <td><a href="https://www.erlang.org/docs">Erlang</a> processes consumed by RabbitMQ, which runs on an Erlang VM.<br><br>
@@ -397,7 +397,7 @@ All BOSH-deployed components generate the following system health metrics. Comin
 
 ## <a id="reference"></a>Component Metric Reference
 
-RabbitMQ for PCF component VMs emit the following raw metrics. The full name of the metric follows the format: `/p-rabbitmq/COMPONENT/METRIC-NAME`
+RabbitMQ for PCF component VMs emit the following raw metrics. The full name of the metric follows the format: `/p.rabbitmq/COMPONENT/METRIC-NAME`
 
 ### <a id="rabbitmq-metrics"></a>RabbitMQ&nbsp; Server Metrics
 
@@ -410,100 +410,100 @@ RabbitMQ for PCF message server components emit the following metrics.
         <th>Description</th>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq.rabbitmq.heartbeat</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/heartbeat</code></td>
         <td>boolean</td>
         <td>Indicates whether the RabbitMQ server is available and able to respond to requests</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/erlang/erlang_processes</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/erlang/erlang_processes</code></td>
         <td>count</td>
         <td>The number of Erlang processes</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/system/memory</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/system/memory</code></td>
         <td>MB</td>
         <td>The memory in MB used by the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/connections/count</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/connections/count</code></td>
         <td>count</td>
         <td>The total number of connections to the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/consumers/count</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/consumers/count</code></td>
         <td>count</td>
         <td>The total number of consumers registered in the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/delivered</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/delivered</code></td>
         <td>count</td>
         <td>The total number of messages with the status <code>deliver_get</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/delivered_no_ack</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/delivered_no_ack</code></td>
         <td>count</td>
         <td>The number of messages with the status <code>deliver_no_ack</code> on the node</td>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/delivered_rate</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/delivered_rate</code></td>
         <td>rate</td>
         <td>The rate at which messages are being delivered to consumers or clients on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/published</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/published</code></td>
         <td>count</td>
         <td>The total number of messages with the status <code>publish</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/published_rate</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/published_rate</code></td>
         <td>rate</td>
         <td>The rate at which messages are being published by the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/redelivered</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/redelivered</code></td>
         <td>count</td>
         <td>The total number of messages with the status <code>redeliver</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/redelivered_rate</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/redelivered_rate</code></td>
         <td>rate</td>
         <td>The rate at which messages are getting the status <code>redeliver</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/got _no_ack</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/got _no_ack</code></td>
         <td>count</td>
         <td>The number of messages with the status <code>get_no_ack</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/get _no_ack_rate</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/get _no_ack_rate</code></td>
         <td>rate</td>
         <td>The rate at which messages get the status <code>get_no_ack</code> on the node</td>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/pending</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/pending</code></td>
         <td>count</td>
         <td>The number of messages with the status <code>messages_unacknowledged</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/system/file descriptors</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/system/file descriptors</code></td>
         <td>count</td>
         <td>The number of open file descriptors on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/exchanges/count</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/exchanges/count</code></td>
         <td>count</td>
         <td>The total number of exchanges on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/messages/available</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/messages/available</code></td>
         <td>count</td>
         <td>The total number of messages with the status <code>messages_ready</code> on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/queues/count</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/queues/count</code></td>
         <td>count</td>
         <td>The number of queues on the node</td>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq/rabbitmq/channels/count</code></td>
+        <td><code>/p.rabbitmq/rabbitmq/channels/count</code></td>
         <td>count</td>
         <td>The number of channels on the node</td>
     </tr>
@@ -520,7 +520,7 @@ RabbitMQ for PCF service broker components emit the following metric.
         <th>Description</th>
     </tr>
     <tr>
-        <td><code>/p-rabbitmq.service_broker.heartbeat</code></td>
+        <td><code>/p.rabbitmq/service_broker/heartbeat</code></td>
         <td>boolean</td>
         <td>Indicates whether the service broker is available and able to respond to requests</td>
     </tr>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -20,6 +20,7 @@ To view the release notes for another product version, select the version from t
 * Update to RabbitMQ 3.6.11
 * Requires stemcell 3421.XXX
 * This version of the tile can only be installed in an Ops Manager v1.10.3+, v1.11, and v1.12 environments
+* On-demand prefix are now prefixed with `p.rabbitmq`
 
 Features:
 

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -20,7 +20,7 @@ To view the release notes for another product version, select the version from t
 * Update to RabbitMQ 3.6.11
 * Requires stemcell 3421.XXX
 * This version of the tile can only be installed in an Ops Manager v1.10.3+, v1.11, and v1.12 environments
-* On-demand prefix are now prefixed with `p.rabbitmq`
+* On-demand metrics prefixed with `p.rabbitmq` to match the service name
 
 Features:
 


### PR DESCRIPTION
In the upcoming release of 1.10 (and 1.9 will also follow) we are changing the prefix we emit metrics for on-demand instances, from `p.rabbitmq` to `p-rabbitmq`. 

Changing the prefix I changed the header of some tables from using `.` as metric separator to `/` to avoid confusion. A similar intervention can be required in the pre provisioned equivalent section

I updated all the references in the monitoring and add a new feature (it was already missing from the known issues).