### PR TITLE
Update docs to include new disk_free_alarm metric

### DIFF
--- a/monitor-pp.html.md.erb
+++ b/monitor-pp.html.md.erb
@@ -421,6 +421,11 @@ RabbitMQ for PCF message server components emit the following metrics.
         <td>The memory in MB used by the node</td>
     </tr>
     <tr>
+       <td><code>/p.rabbitmq/rabbitmq/system/disk_free_alarm</code></td>
+       <td>boolean</td>
+       <td>Indicates if the disk free alarm has gone off</td>
+    </tr>
+    <tr>
         <td><code>/p-rabbitmq/rabbitmq/connections/count</code></td>
         <td>count</td>
         <td>The total number of connections to the node</td>

--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -434,6 +434,11 @@ RabbitMQ for PCF message server components emit the following metrics.
         <td>The memory in MB used by the node</td>
     </tr>
     <tr>
+       <td><code>/p.rabbitmq/rabbitmq/system/disk_free_alarm</code></td>
+       <td>boolean</td>
+       <td>Indicates if the disk free alarm has gone off</td>
+    </tr>
+    <tr>
         <td><code>/p.rabbitmq/rabbitmq/connections/count</code></td>
         <td>count</td>
         <td>The total number of connections to the node</td>


### PR DESCRIPTION
* This metric indicates when the disk free alarm has gone off.

[#151851504]