### PR TITLE
Update docs to include new disk_free memory alarm metrics

### DIFF
--- a/monitor-pp.html.md.erb
+++ b/monitor-pp.html.md.erb
@@ -420,6 +420,19 @@ RabbitMQ for PCF message server components emit the following metrics.
         <td>MB</td>
         <td>The memory in MB used by the node</td>
     </tr>
+
+    <tr>
+      <td><code>/p.rabbitmq/rabbitmq/system/mem_alarm</code></td>
+      <td>boolean</td>
+      <td>Indicates if the memory alarm has gone off</td>
+    </tr>
+
+    <tr>
+      <td><code>/p.rabbitmq/rabbitmq/system/disk_free_alarm</code></td>
+      <td>boolean</td>
+      <td>Indicates if the disk free alarm has gone off</td>
+    </tr>
+
     <tr>
         <td><code>/p-rabbitmq/rabbitmq/connections/count</code></td>
         <td>count</td>

--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -433,6 +433,19 @@ RabbitMQ for PCF message server components emit the following metrics.
         <td>MB</td>
         <td>The memory in MB used by the node</td>
     </tr>
+
+    <tr>
+      <td><code>/p.rabbitmq/rabbitmq/system/mem_alarm</code></td>
+      <td>boolean</td>
+      <td>Indicates if the memory alarm has gone off</td>
+    </tr>
+
+    <tr>
+      <td><code>/p.rabbitmq/rabbitmq/system/disk_free_alarm</code></td>
+      <td>boolean</td>
+      <td>Indicates if the disk free alarm has gone off</td>
+    </tr>
+
     <tr>
         <td><code>/p.rabbitmq/rabbitmq/connections/count</code></td>
         <td>count</td>


### PR DESCRIPTION
Hi Docs Team,

the code is not yet in the product. So we can't publish this doc yet, only after cutting the new version of the product.

Let's sync when we would like to publish a new version of 1.10 doc.

thank you,
Alberto