### PR TITLE
Release notes for 1.10.5

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -65,11 +65,11 @@ The following table provides version and version-support information about Rabbi
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.10.0</td>
+        <td>v1.10.5</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>October 16, 2017</td>
+        <td>November 2, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -17,6 +17,46 @@ To view the release notes for another product version, select the version from t
 
 ## <a id="110x"></a>v1.10.x
 
+### <a id="1105"></a> v1.10.5
+
+**Release Date**: November 3, 2017
+
+#### Features
+
+**On-Demand**
+
+* Requires stemcell 3445.16
+* Adds queue depth, memory alarm, and disk alarm metrics
+
+**Pre-Provisioned**
+
+* Requires stemcell 3445.16
+* Increases max HAProxy connections to 64000
+* Removes the stats UI on HAProxy instances
+* Allows for more granular TLS protocol version selection
+* Adds queue depth, memory alarm, and disk alarm metrics
+* Fixes known issue where some invalid characters in the administrator password
+
+#### Known Issues
+
+* Cluster scaling or changing the [Erlang Cookie](./install-config-pp.html#erlang) value require cluster downtime,
+  and might result in failed deployments.
+  For more information, see [Cluster Scaling Known Issue](./install-config-pp.html#scaling-issue) and
+[Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
+
+* Changing networks and/or IP addresses for the `RabbitMQ Server` job results in a failed deployment.
+  For more information, see [Changing Network or IP Addresses Results in a Failed Deployment](./changing-ips.html).
+
+* When errand run rules are set to **When Changed**, Ops Manager may not run the errands when the tile has relevant changes.
+  For more information, see [Managing Errands in Ops Manager](https://docs.pivotal.io/pivotalcf/1-11/customizing/managing_errands.html).
+  Pivotal recommends leaving the default run rule set to **On**.
+
+#### Packages
+
+* OSS RabbitMQ v3.6.12
+* Erlang v19.3.6.2
+* HAProxy v1.6.11
+
 ### <a id="1103"></a> v1.10.3
 
 **Release Date**: October 16, 2017
@@ -51,7 +91,7 @@ To view the release notes for another product version, select the version from t
 
 * Cluster scaling or changing the [Erlang Cookie](./install-config-pp.html#erlang) value require cluster downtime,
   and might result in failed deployments.
-  For more information, see [Cluster Scaling Known Issue](./install-config-pp.html#scaling-issue) and 
+  For more information, see [Cluster Scaling Known Issue](./install-config-pp.html#scaling-issue) and
 [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
 
 * Changing networks and/or IP addresses for the `RabbitMQ Server` job results in a failed deployment.
@@ -61,11 +101,11 @@ To view the release notes for another product version, select the version from t
   For more information, see [Managing Errands in Ops Manager](https://docs.pivotal.io/pivotalcf/1-11/customizing/managing_errands.html).
   Pivotal recommends leaving the default run rule set to **On**.
 
-* Certain special characters cannot be used with the RabbitMQ administrator password, and using them can lead to issues 
+* Certain special characters cannot be used with the RabbitMQ administrator password, and using them can lead to issues
 logging into the Management UI as that user.
 
 #### Packages
 
 * OSS RabbitMQ v3.6.12
-* Erlang v19.3.6
+* Erlang v19.3.6.2
 * HAProxy v1.6.11


### PR DESCRIPTION
[#152344861]

This is ready to be published at 1.10.5 has been made GA. Also, please let us know if this structure for release notes in 1.10 works for you going forward.

Signed-off-by: Scott Muc <smuc@pivotal.io>