### PR TITLE
Fixes typo to the file "deploying.html.md.erb"

### DIFF
--- a/deploying.html.md.erb
+++ b/deploying.html.md.erb
@@ -12,7 +12,7 @@ The deployment includes a single load balancer `haproxy` which spreads connectio
 
 The deployment will occur in a single availability zone (AZ).
 
-The default configuration is for testing purposes only and it is recommended that customers have a minium of **3 RabbitMQ nodes** and **2 HAProxy nodes**
+The default configuration is for testing purposes only and it is recommended that customers have a minimum of **3 RabbitMQ nodes** and **2 HAProxy nodes**
 
 <%= image_tag("images/deployment_default.jpeg") %>
 


### PR DESCRIPTION
Fixes to the typo, i.e replace "minium" to minimum