### PR TITLE
151852562 fix upgrade paths link

### DIFF
--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -6,7 +6,7 @@ owner: London Services
 This product enables automated upgrades between versions of the product and is deployed through Ops Manager, and due to RabbitMQ product limitations may require the cluster to be taken offline.  When this is necessary it is clearly noted in the release notes for that version.
 
 Note there is a difference between the cluster remaining available during a tile upgrade/update, and an individual queue placed on nodes in a cluster.
-The upgrade paths are detailed [here](http://docs.pivotal.io/rabbitmq-cf/index.html) for each released version.
+The upgrade paths are detailed on the [Pivotal Network - RabbitMQ for PCF page](https://network.pivotal.io/products/p-rabbitmq).
 
 A reference guide for deployments is shown the table below.  Please be aware that this is a guide only and that the release notes for the version you are updating to must be checked before upgrading.
 
@@ -46,8 +46,6 @@ A reference guide for deployments is shown the table below.  Please be aware tha
   </td>
 </tr>
 </table>
-
-The specific upgrade paths are detailed [here](http://docs.pivotal.io/rabbitmq-cf/index.html) for each released version.
 
 <p class="note"><strong>Note</strong>: For specific information about updating RabbitMQ for PCF from v1.6.0–v1.6.4,
 see <a href="http://docs.pivotal.io/rabbitmq-cf/1-6-6/updating.html">Updating RabbitMQ for PCF from versions v1.6.x to v1.6.6</a>.</p>

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -47,14 +47,6 @@ A reference guide for deployments is shown the table below.  Please be aware tha
 </tr>
 </table>
 
-<p class="note"><strong>Note</strong>: For specific information about updating RabbitMQ for PCF from v1.6.0–v1.6.4,
-see <a href="http://docs.pivotal.io/rabbitmq-cf/1-6-6/updating.html">Updating RabbitMQ for PCF from versions v1.6.x to v1.6.6</a>.</p>
-
-<p class="note"><strong>Note</strong>: For specific information about updating
-RabbitMQ for PCF from v1.6.0–v1.6.4, see <a
-href="http://docs.pivotal.io/rabbitmq-cf/1-6-6/updating.html">Updating RabbitMQ
-for PCF from versions v1.6.x to v1.6.6</a>.</p>
-
 To upgrade the product:
 
 * The Operator should download the latest version of the product from [Pivotal Network](https://network.pivotal.io/products/pivotal-rabbitmq-service)


### PR DESCRIPTION
- the link was pointing to the landing page, where we have no
information about upgrade paths
- we are using a pivnet link where that information can be found
- we removed references to old tile versions