### PR TITLE
Add release notes for 1.7.34

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -18,11 +18,11 @@ The following table provides version and version-support information about Rabbi
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.7.33</td>
+        <td>v1.7.34</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 14, 2017</td>
+        <td>December 15, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -14,8 +14,8 @@ See the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matr
 
 Pivotal released v1.7.0 in September 2016, and the latest patch version is v1.7.31.
 
-### <a id="1733"></a> v1.7.33
-**Release Date: December 14, 2017**
+### <a id="1734"></a> v1.7.34
+**Release Date: December 15, 2017**
 
 <p class="note warning"> <strong>IMPORTANT</strong>: If you are upgrading from v1.7.14 or earlier, you will experience a 
   <strong>small window of downtime</strong> 


### PR DESCRIPTION
In fact 1.7.33 (and 32) had minor issues we captured before releasing. This is
why we will go from 1.7.31 to 1.7.34.

[#153556159]

Signed-off-by: Vlad Stoian <vstoian@pivotal.io>