### PR TITLE
Add release notes for 1.8.25

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -62,11 +62,11 @@ The following table provides version and version-support information about Rabbi
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.8.23</td>
+        <td>v1.8.25</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 14, 2017</td>
+        <td>December 15, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -11,9 +11,9 @@ For product versions and upgrade paths, see the [Product Compatibility Matrix](h
 
 ## <a id="18x"></a>v1.8.x
 
-### v1.8.23
+### v1.8.25
 
-**Release Date:  December 14, 2017**
+**Release Date:  December 15, 2017**
 
 #### Features
 


### PR DESCRIPTION
We found minor issues with 1.8.22-24, that's why we are jumping from
1.8.21 to 1.8.25.

[#153556128]

Signed-off-by: Diego Lemos <dlresende@pivotal.io>