### PR TITLE
Removed co-located errands mention from features

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -132,7 +132,6 @@ For more information, see [Unlocking the Power of On-Demand RabbitMQ for PCF](./
 * Configure the end point for the RabbitMQ Syslog
 * RabbitMQ and HAProxy metrics are exposed on the firehose
 * Syslog forwarding on by default
-* Errands are run on colocated VMs to decrease deployment times
 
 
 


### PR DESCRIPTION
Remove co-located errands from feature list in pre-provisioned as it is no longer shipped in the product. 