### PR TITLE
Operator must ensure there's no on-demand service instance running before bumping to 1.13

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -13,53 +13,25 @@ upgrade to the latest v1.11.x version before upgrading to the latest v1.12.x ver
 For product versions and upgrade paths,
 see the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matrix.pdf).
 
-## <a id="use-new-plans"></a> Use RabbitMQ v3.7 On-Demand Plans
+## <a id="use-rmq-3-7"></a> Delete existing On-Demand service instances running RabbitMQ v3.6
 
-RabbitMQ v3.7 plans are available.
-Ensure that all apps use the RabbitMQ v3.7 on-demand plans instead of the RabbitMQ v3.6 on-demand plans.
+Only RabbitMQ v3.7 plans are available. Plans using RabbitMQ 3.6 have been removed.
+Ensure that all instances running RabbitMQ 3.6 have been deleted before
+upgrading to RabbitMQ For PCF 1.13. Deployment is expected to fail in case
+there is any remaining on demand service instance running with RabbitMQ 3.6.
 
 For more information, see the following:
 
 + [About Upgrading On-Demand Instances from RabbitMQ v3.6 to v3.7](./upgrade.html#upgrade-ondemand)
-+ The [ANN RabbitMQ 3.6.x support timeline](https://groups.google.com/forum/#!msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ)
-  post on the RabbitMQ users forum
++ [Check remaining On-Demand Instances](./upgrade.html#existing-ondemand-instances)
 
+## <a id="113x"></a>v1.13
 
-## <a id="112x"></a>v1.12
+### <a id="1130"></a> v1.13.0
 
-### <a id="1123"></a> v1.12.3
-
-**Release Date**: April 19, 2018
+**Release Date**: XX
 
 #### Features
-
-**On-Demand**
-
-  * The following errands are colocated with their respective broker to decrease errand run time and VM footprint:
-    - Register / Deregister On Demand Service Broker
-    - On Demand Instance Smoke Tests
-    - Upgrade All Service Instances
-    - Delete All Service Instances
-
-    For more information about errands, see [Errands](http://docs.pivotal.io/tiledev/tile-errands.html).
-
-  * [Beta] Service Sharing allows RabbitMQ deployments to be shared across Cloud Foundry spaces and orgs.
-
-     For more information about sharing service intances,
-     see [Cloud Foundry Documentation](https://docs.cloudfoundry.org/devguide/services/sharing-instances.html).
-
-  * [Beta] Support for secure credentials (CredHub).
-     Credentials are stored in a central repository and are restricted to components that actually need them.
-
-  For more information about CredHub, see [Cloud Foundry Documentation](https://docs.cloudfoundry.org/credhub/index.html).
-
-**Pre-Provisioned**
-
-  * The following errands are colocated with their respective broker to decrease errand run time and VM footprint:
-    - Broker Registrar / Deregistrar
-    - Smoke Tests errands
-
-    For more information about errands, see [Errands](http://docs.pivotal.io/tiledev/tile-errands.html).
 
 #### Known Issues
 
@@ -77,7 +49,6 @@ For more information, see the following:
 
 #### Packages
 
-* OSS RabbitMQ v3.6.15
 * OSS RabbitMQ v3.7.4
 * Erlang v19.3.6.4
 * HAProxy v1.6.13

--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -222,13 +222,51 @@ RabbitMQ for PCF v1.12 provides on-demand service plans with RabbitMQ v3.6 and v
 App developers can either start fresh with a v3.7 on-demand instance or they can migrate
 their RabbitMQ v3.6 instances to RabbitMQ v3.7 using blue-green app deployments without downtime.
 
-To enable the migration from on-demand v3.6 instances to v3.7 instances, the on-demand v3.7 plans should be configured to mirror the existing v3.6 plans. 
+To enable the migration from on-demand v3.6 instances to v3.7 instances, the on-demand v3.7 plans should be configured to mirror the existing v3.6 plans.
 For more information,
 see the blog [Blue-Green Application Deployments with RabbitMQ](https://content.pivotal.io/blog/blue-green-application-deployments-with-rabbitmq)
 and the video [Blue-Green Deployment of Applications leveraging RabbitMQ](https://www.youtube.com/watch?v=S2oO-t-E38c).
 
 RabbitMQ v3.6 on-demand plans will be removed in an upcoming RabbitMQ for PCF tile release.
 Encourage all developers to move their apps away from these plans.
+
+## <a id="existing-ondemand-instances"></a> Check remaining On-Demand Service Instances
+
+Before proceeding with the upgrade from RabbitMQ For PCF 1.12.x to 1.13.x
+ensure that there is no On-Demand service instance running with RabbitMQ Server
+3.6. RabbitMQ 3.6 has been removed from the tile 1.13.x, which means that
+deployment will fail if any On-Demand service instance is running with RabbitMQ
+3.6.
+
+In order to search for existing On-Demand 3.6 Service instances run the
+following commands (it's assumed that you have target the CF deployment used in
+the environment you want to upgrade):
+
+1. Search for service offering called `p.rabbitmq` - That's the On-Demand offering:
+
+```
+   cf curl /v2/services?q=label:p.rabbitmq
+```
+
+1. The output will contain the `service_plans_url` containing the url for all
+service plans, then run `cf curl` against that url:
+
+```
+  cf curl /v2/services/<SERVICE-GUID>/service_plans
+```
+
+1. That will return a list with all RabbitMQ On-Demand service plans, which
+might include plans using RabbitMQ 3.6 and RabbitMQ 3.7. You need to select
+only plans using RabbitMQ 3.6.For each plan using RabbitMQ 3.6 there'll be a
+property `service_instances_url`, then run `cf curl` against the url for each
+service plan found:
+
+```
+  cf curl /v2/service_plans/<SERVICE-PLAN-GUID>/service_instances
+```
+
+1. The result should be 0 instances for all service plans using RabbitMQ 3.6.
+
 
 ## <a id="policy"></a> Release Policy
 


### PR DESCRIPTION
Add information for operators to delete On-Demand service instances before upgrading to 1.13

* Include instructions on how to search for existing on-demand instances

[#156169807]