### PR TITLE
Fix link for PCF "Managing Errands" page

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -49,7 +49,7 @@ For more information about troubleshooting smoke tests, see [Smoke Tests](./smok
   For more information, see [Changing Network or IP Addresses Results in a Failed Deployment](./changing-ips.html).
 
 * When errand run rules are set to **When Changed**, Ops Manager may not run the errands when the tile has relevant changes.
-  For more information, see [Managing Errands in Ops Manager](https://docs.pivotal.io/pivotalcf/1-11/customizing/managing_errands.html).
+  For more information, see [Managing Errands in Ops Manager](https://docs.pivotal.io/pivotalcf/2-1/customizing/managing_errands.html).
   Pivotal recommends leaving the default run rule set to **On**.
 
 #### Packages


### PR DESCRIPTION
Hi docs team,

we noticed that we have an invalid link for pivotal-cf page. Our 1.12 product is not compatible with PCF 1.11, but 2.0 and 2.1.

Co-authored-by: Rosie Bloxsom <rbloxsom@pivotal.io>