### PR TITLE
Add production checklist from RMQ OS docs

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -5,6 +5,8 @@ owner: London Services
 
 This topic provides instructions to Pivotal Cloud Foundry (PCF) operators about how to install, configure, and deploy the RabbitMQ for PCF tile to provide on-demand service.
 
+The RabbitMQ Open Source product provides additional documentation, including a [Production Checklist](https://community.pivotal.io/s/article/Rotating-CA-Certificates-for-Pivotal-Cloud-Foundry-Services)
+
 <p class="note"><strong>Note</strong>: For instructions on how to install, configure, and deploy the RabbitMQ for PCF tile
 as a pre-provisioned service, see
 <a href="./install-config-pp.html">Installing and Configuring the Pre-Provisioned Service</a>.</p>


### PR DESCRIPTION
@murphe5 can you please review the location of this?

docs team - could we please also add this same commit to this page: https://docs.pivotal.io/rabbitmq-cf/1-13/install-config-pp.html in the same place

This change should probably be backported