### PR TITLE
Initial release notes for v1.14

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -39,20 +39,9 @@ Installing and Configuring RabbitMQ for PCF the On-Demand Service</a>.
 
 New features and changes in this release:
 
-* Supports securing communication between apps and on-demand 
-service instances using Transport Layer Security (TLS).
-For more information, see [Preparing for TLS](./prepare-tls.html). 
-For ease of upgrade from previous versions, this functionality is turned off by default.
+* On-Demand instances with TLS enabled will use HTTPS instead of HTTP inside the PCF network.
 
-* Includes open source RabbitMQ v3.7.
-  This version includes many improvements.
-  For information about what is new in RabbitMQ v3.7,
-  see the [RabbitMQ documentation](http://www.rabbitmq.com/blog/2018/02/05/whats-new-in-rabbitmq-3-7/).
-  The path to upgrade the pre-provisioned service to v3.7 requires manual intervention,
-  and the path to upgrade the on-demand service requires removing preexisting instances.
-  For information, see [Upgrading RabbitMQ for PCF](upgrade.html).
-
-* Smoke tests for the on-demand broker now use the system org, as is already the case for multi-tenant.
+* Compiled BOSH releases are used, resulting in improved deployment times.
 
 ### Known Issues
 


### PR DESCRIPTION
Note that HTTPS has been used outside of the PCF network for a while.  This change would not be easily observable by a customer.

[#158489613]