### PR TITLE
Indicate upgrade compatibility with 2.2.6+

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -11,8 +11,8 @@ For example, if you use an older v1.12.x version,
 upgrade to the latest v1.12.x version before upgrading to the latest v1.13.x version.
 
 <p class="note warning"><strong>WARNING</strong>:
-  It is not possible to upgrade from RabbitMQ for PCF v1.12.7 to v1.13.x on PCF v2.2. 
-  Pivotal recommends doing this upgrade path on PCF v2.1.</p>
+  It is only possible to upgrade from RabbitMQ for PCF v1.12.7 to v1.13.x on PCF v2.2.6+.
+</p>
 
 For product versions and upgrade paths,
 see the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matrix.pdf).
@@ -42,6 +42,8 @@ Requires stemcell [3586.36](https://github.com/cloudfoundry/bosh-linux-stemcell-
 ### Known Issues
 
 This release has the following known issues:
+
+* You cannot upgrade from PCF v.12 to PCF v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
 
 * Cluster scaling or changing the Erlang cookie value require cluster downtime
   and might result in failed deployments. For more information, see [Erlang Cookie](./install-config-pp.html#erlang), [Cluster Scaling Known Issue](./install-config-pp.html#scaling-issue), and [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
@@ -76,6 +78,8 @@ New features and changes in this release:
 ### Known Issues
 
 This release has the following known issues:
+
+* You cannot upgrade from PCF v.12 to PCF v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
 
 * If you are upgrading RabbitMQ for PCF v1.12 to v1.13 and you use Spring Cloud Services,
   you must disable all errands in the Spring Cloud Services tile during the upgrade to ensure that the upgrade succeeds. 
@@ -123,6 +127,8 @@ For ease of upgrade from previous versions, this functionality is turned off by 
 ### Known Issues
 
 This release has the following known issues:
+
+* You cannot upgrade from PCF v.12 to PCF v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
 
 * Cluster scaling or changing the [Erlang Cookie](./install-config-pp.html#erlang) value require cluster downtime,
   and might result in failed deployments.

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -43,7 +43,7 @@ Requires stemcell [3586.36](https://github.com/cloudfoundry/bosh-linux-stemcell-
 
 This release has the following known issues:
 
-* You cannot upgrade from PCF v.12 to PCF v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
+* You cannot upgrade from RabbitMQ for PCF v.12 to v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
 
 * Cluster scaling or changing the Erlang cookie value require cluster downtime
   and might result in failed deployments. For more information, see [Erlang Cookie](./install-config-pp.html#erlang), [Cluster Scaling Known Issue](./install-config-pp.html#scaling-issue), and [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
@@ -79,7 +79,7 @@ New features and changes in this release:
 
 This release has the following known issues:
 
-* You cannot upgrade from PCF v.12 to PCF v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
+* You cannot upgrade from RabbitMQ for PCF v.12 to v1.13 on PCF v2.2.0-2.2.5. You must upgrade on PCF v2.1 or on PCF v2.2.6+
 
 * If you are upgrading RabbitMQ for PCF v1.12 to v1.13 and you use Spring Cloud Services,
   you must disable all errands in the Spring Cloud Services tile during the upgrade to ensure that the upgrade succeeds. 


### PR DESCRIPTION
Change the warning - making it informational and about 2.2.6+

Add known issues to all patches saying dont upgrade on 2.2.0-2.2.5