### PR TITLE
Update release notes for 1.14.1

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -14,7 +14,7 @@ For product versions and upgrade paths,
 see the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matrix.pdf).
 
 <p class="note"><strong>Note:</strong> Spring Cloud Services (SCS) will soon be dropping the dependency on RabbitMQ.
-Pivotal recommends that SCS users do not upgrade to RabbitMQ for PCF v1.13.0.</p>
+Pivotal recommends that SCS users do not upgrade to RabbitMQ for PCF v1.13+.</p>
 
 ## <a id="deprecation"></a> Pre-Provisioned Service to be Deprecated
 
@@ -31,9 +31,9 @@ as an on-demand service, see <a href="./install-config.html">
 Installing and Configuring RabbitMQ for PCF the On-Demand Service</a>.
 
 
-## <a id="1140"></a> v1.14.0
+## <a id="1141"></a> v1.14.1
 
-**Release Date**: September 28, 2018
+**Release Date**: October 2, 2018
 
 <p class="note breaking"><strong>Breaking Change:</strong>
   RabbitMQ for PCF v1.14 and later requires a Xenial stemcell.
@@ -45,6 +45,12 @@ Installing and Configuring RabbitMQ for PCF the On-Demand Service</a>.
   <a href="https://network.pivotal.io/products/stemcells-ubuntu-xenial">Stemcells for PCF (Ubuntu Xenial)</a>.
   For instructions on importing the stemcell, see
   <a href="https://docs-pcf-staging.cfapps.io/pivotalcf/opsguide/managing-stemcells.html">Importing and Managing Stemcells</a>.</p>
+
+<p class="note breaking"><strong>Breaking Change:</strong>
+  Syslog forwarding uses RFC5424 format, and the Legacy Format is no longer available.
+  If you are upgrading and have Legacy Format selected in your existing syslog configuration,
+  that setting is automatically reconfigured to use the RFC5424 format.
+</p>
 
 ### Features
 
@@ -65,10 +71,6 @@ New features and changes in this release:
   That means that RabbitMQ instances are recreated based on the new stemcell whenever a newer patch release of the stemcell becomes available.
   You can opt out of using a given stemcell version for any specific tile or 
   deployment using OpsManager [Stemcell Library](https://docs.pivotal.io/pivotalcf/2-2/opsguide/managing-stemcells.html).
-
-* Syslog forwarding uses RFC5424 format, and the Legacy Format is no longer available.
-  If you are upgrading and have Legacy Format selected in your existing syslog configuration,
-  that setting is automatically reconfigured to use the RFC5424 format.
 
 ### Known Issues
 


### PR DESCRIPTION
- mention that customers using RMQ as a dependency to SCS should not
upgrade since 1.13+ (and not only 1.13)
- add .1 patch to 1.14 (we had an issue with 1.14.0 and we will not make
it publicly available)
- add syslog change as a breaking change since some customers won't be
able to use the legacy syslog format anymore

[#158975911]

Co-authored-by: Diego Lemos <dlresende@pivotal.io>