### PR TITLE
Add consistent hash exchange to list of enabled plugins for ODB

### DIFF
--- a/use.html.md.erb
+++ b/use.html.md.erb
@@ -321,7 +321,10 @@ The following plugins are enabled explicitly in an On-Demand RabbitMQ for PCF in
 * `rabbitmq_shovel`---For more information, see [Shovel Exchanges and Queues](#shovel) below.
 
 * `rabbitmq_sharding`---For more information, see the
-[rabbitmq sharding](https://github.com/rabbitmq/rabbitmq-sharding) GitHub repository.
+[rabbitmq sharding](https://github.com/rabbitmq/rabbitmq-sharding/blob/master/README.md) GitHub repository.
+
+* `rabbitmq_consistent_hash_exchange`---For more information, see the
+[rabbitmq consistent hash exchange](https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange/blob/master/README.md) GitHub repository.
 
 The list of enabled plugins is not configurable.
 


### PR DESCRIPTION
[#160616925]

Co-authored-by: George Blue <gblue@pivotal.io>