### PR TITLE
STOMP and MQTT not enabled for dedicated instances

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -476,10 +476,6 @@ To create an admin user on a RabbitMQ instance do the following:
 
 The following plugins are enabled by default and cannot be disabled:
 
-* `rabbitmq_mqtt`
-
-* `rabbitmq_stomp`
-
 * `rabbitmq_management`---For more information see
 [Management Plugin](https://www.rabbitmq.com/management.html) in the RabbitMQ documentation.
 


### PR DESCRIPTION
[#161476735]

This fix applies to previous versions too and should be cherry-picked.  Would you like me to submit PRs for that?

Note that the sharding and consistent_hash_exchange plugins are not enabled for v1.14 or earlier.