### PR TITLE
Mention client reconnects

### DIFF
--- a/upgrade.html.md.erb
+++ b/upgrade.html.md.erb
@@ -52,6 +52,9 @@ the upgrade and you must not interrupt this process.
   These counts are the default.
   For more information, see [Clustering and Network Partitions](./partitions.html).
 
+* To benefit from the rolling upgrades you need to configure your applications to reconnect after a node restarts.
+  See [Handling Node Restarts in Applications](https://www.rabbitmq.com/upgrade.html#rabbitmq-restart-handling) in the RabbitMQ docs for more details.
+
 * Ops Manager ensures the instances are updated with the new packages and any
 configuration changes are applied automatically.
 


### PR DESCRIPTION
Hey docs team :). 

This change is relevant to all supported versions of the tile. Would you like us to create PR's for all the additional branches?

- When upgrading people want to know if they need to do anything on the
client side
- We added a link to the rabbitmq docs to inform them what to do

[#153211541]

Co-authored-by: Daniil Fedotov <hairyhum@pivotal.io>