### PR TITLE
Add info about a known issue

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -63,6 +63,9 @@ New features and changes in this release:
 
 This release has the following known issues:
 
+* If you upgrading to this version, you'll not see RabbitMQ metrics on the loggregator firehose anymore.
+  A new version fixing this issue will be released soon. The problem doesn't affect new installations - only upgrades.
+
 * You cannot upgrade from RabbitMQ for PCF v1.12 to v1.13 on PCF v2.2.0 - v2.2.5.
   You must upgrade on PCF v2.1 or on PCF v2.2.6 or later.
 


### PR DESCRIPTION
Latest 1.13 doesn't emit metrics to the firehose