### PR TITLE
Update release notes for v1.15

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -72,7 +72,7 @@ The following table provides version and version-support information about Rabbi
     </tr>
     <tr>
         <td>Release date</td>
-        <td>December 19, 2018</td>
+        <td>December 20, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -30,9 +30,9 @@ For instructions on how to install, configure, and deploy RabbitMQ for PCF
 as an on-demand service, see <a href="./install-config.html">
 Installing and Configuring RabbitMQ for PCF the On-Demand Service</a>.
 
-## <a id="1151"></a> v1.15.2
+## <a id="1152"></a> v1.15.2
 
-**Release Date**: December 19, 2018
+**Release Date**: December 20, 2018
 
 ### Features
 
@@ -61,6 +61,8 @@ for an on-demand service instance using the command `cf tail`.
 
 * The maximum number of on-demand services instances that can be deployed has been increased to 200.
 
+* Set swap to 1 GB for RabbitMQ nodes.
+
 ### Known Issues
 
 This release has the following known issues:
@@ -81,7 +83,7 @@ This release has the following known issues:
 ### Packages
 
 * OSS RabbitMQ v3.7.9
-* Erlang v20.3.8.14
+* Erlang v20.3.8.15
 * HAProxy v1.6.13
 
 ## <a id="view"></a> View Release Notes for Another Version


### PR DESCRIPTION
- v1.15.1 will not be released. We have added release notes for v1.15.2.

[#162540709]

Co-authored-by: George Blue <gblue@pivotal.io>