### PR TITLE
Document disabling service metrics

### DIFF
--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -428,7 +428,7 @@ To specify the destination for RabbitMQ for PCF log messages, do the following:
     <tr>
         <td><strong>Metrics polling interval</strong></td>
         <td>The default setting is 30 seconds for all deployed components. Pivotal recommends that you do not change this interval.
-        In order to avoid overwhelming components, do not set this below 10 seconds.
+        In order to avoid overwhelming components, do not set this below 10 seconds. Metrics can be disabled by setting this to -1.
         Changing this setting affects all deployed instances.</td>
     </tr>
     <tr>

--- a/monitor-pp.html.md.erb
+++ b/monitor-pp.html.md.erb
@@ -37,7 +37,7 @@ RabbitMQ and HAProxy servers log at the <code>info</code> level and capture erro
 ## <a id="metrics"></a>Metrics
 
 Metrics are regularly-generated log messages that report measured component states. The metrics polling interval defaults to 30 seconds.
-The **metrics polling interval** is a configuration option on the RabbitMQ tile (**Settings** > **RabbitMQ**).  The interval setting applies to all components deployed by the tile.
+The **metrics polling interval** is a configuration option on the RabbitMQ tile (**Settings** > **RabbitMQ**). Setting this interval to -1 disables metrics. The interval setting applies to all components deployed by the tile.
 
 Metrics are long, single lines of text that follow the format:
 

--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -39,7 +39,7 @@ To specify the destination for RabbitMQ for PCF log messages, do the following:
     <tr>
         <td><strong>Metrics polling interval</strong></td>
         <td>The default setting is 30 seconds for all deployed components. Pivotal recommends that you do not change this interval.
-        In order to avoid overwhelming components, do not set this below 10 seconds.
+        In order to avoid overwhelming components, do not set this below 10 seconds. Metrics can be disabled by setting this to -1.
         Changing this setting affects all deployed instances.</td>
     </tr>
     <tr>
@@ -91,7 +91,7 @@ The RabbitMQ VMs log at the <code>info</code> level and capture errors, warnings
 ## <a id="metrics"></a>What Are Metrics
 
 Metrics are regularly-generated log messages that report measured component states. The metrics polling interval defaults to 30 seconds.
-The **metrics polling interval** is a configuration option on the RabbitMQ tile (**Settings** > **RabbitMQ**).  The interval setting applies to all components deployed by the tile.
+The **metrics polling interval** is a configuration option on the RabbitMQ tile (**Settings** > **RabbitMQ**). Setting this interval to -1 disables metrics. The interval setting applies to all components deployed by the tile.
 
 Metrics are long, single lines of text that follow the format:
 

--- a/ondemand.html.md.erb
+++ b/ondemand.html.md.erb
@@ -352,7 +352,7 @@ The following are preconfigured for both the single node and the cluster plans:
         Pivotal recommends you set this value to be twice the amount of RAM of the selected **RabbitMQ VM Type**.
 
 * **Metrics**---Emitted to the Loggregator Firehose for all on-demand instances.
-  The polling interval is set in the Ops Manager, in the **Metrics polling interval** field, in the **Pre-Provisioned RabbitMQ** tab of the RabbitMQ for PCF tile.
+  The polling interval is set in Ops Manager, in the **Metrics polling interval** field, in the **Pre-Provisioned RabbitMQ** tab of the RabbitMQ for PCF tile.
   Due to the impact of some of the cluster settings detailed below,
   Pivotal strongly recommends that you monitor the exposed metrics
   and configure alarms as recommended in [Monitoring and KPIs for On-Demand RabbitMQ for PCF](./monitor.html#kpi).


### PR DESCRIPTION
The key information added is that service metrics can be disabled by setting the "Metrics Polling Interval" to -1.