### PR TITLE
Notify that we have removed this release

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -406,6 +406,8 @@ This release has the following known issues:
 
 **Release Date**: September 13, 2018
 
+((This release has been removed** due to a bug with the version of OSS RabbitMQ.
+
 ### Features
 
 New features and changes in this release:


### PR DESCRIPTION
Can we please also add this notice to 1.14.1 as well? This is medium-urgency 

Please confirm to me once these are live as I will then take the pivnet release down.