### PR TITLE
Changing the "recommend" on upgrading to mandatory

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -7,7 +7,7 @@ owner: London Services
 
 <%= partial 'do-not-upgrade' %>
 
-Pivotal recommends that you upgrade to the latest version of your current minor line,
+To upgrade from 1.12.x to 1.13.x, you **must** upgrade to the latest version of your current minor line,
 then upgrade to the latest available version of the new minor line.
 For example, if you use an older v1.12.x version,
 upgrade to the latest v1.12.x version before upgrading to the latest v1.13.x version.


### PR DESCRIPTION
We have seen support tickets where customers upgrade from for example, 1.12.5 - 1.13.16, and the upgrade fails. This change should help call this problem out.