### PR TITLE
Remove 3.6 references

### DIFF
--- a/ondemand.html.md.erb
+++ b/ondemand.html.md.erb
@@ -137,22 +137,6 @@ This plan offers:
 * Updates and upgrades initiated and controlled by the operator to keep the instance up-to-date with the latest security patches and issue fixes
 * Message resilience provided through RabbitMQ exchange, queue Federation, and Shovel plugins.
 
-### <a id="singlenode-RMQ36"></a> To Be Deprecated: On-Demand Single Node Plan Using RabbitMQ 3.6
-
-This plan provides the same benefits as described above, but uses RabbitMQ 3.6 for backwards compatibility.
-
-RabbitMQ 3.6 is reaching end of support.
-Consider moving to RabbitMQ 3.7 as soon as possible.
-For more information about support for RabbitMQ 3.6,
-see the [RabbitMQ 3.6.x support time line announcement](https://groups.google.com/forum/#!msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ).
-
-If you are already using RabbitMQ for PCF, you can choose to provide service plans
-with RabbitMQ 3.6 for backwards compatibility.
-However, you should also enable RabbitMQ 3.7 plans to allow developers to migrate to the new version.
-
-For new deployments, Pivotal recommends disabling all RabbitMQ 3.6 plans and using
-RabbitMQ 3.7 to avoid the need to upgrade in the near future.
-
 ## <a id="cluster"></a> On-Demand Cluster Plan Using RabbitMQ 3.7
 
 Like the single node plan, this plan is designed to be simple to configure, deploy and use.
@@ -169,24 +153,6 @@ This plan offers:
 * Admin access to the RabbitMQ Management UI to give app developer teams full control over the cluster
 * Updates and upgrades initiated and controlled by the operator to keep the instance up-to-date with the latest security patches and issue fixes.
 * Message resilience provided by mirroring queues across RabbitMQ nodes, and the option to use the Federation and Shovel plugins.
-
-
-
-### <a id="cluster-RMQ36"></a> To Be Deprecated: On-Demand Cluster Plan Using RabbbitMQ 3.6
-
-This plan provides the same benefits as described above, but uses RabbitMQ 3.6 for backwards compatibility.
-
-RabbitMQ 3.6 is reaching end of support.
-Consider moving to RabbitMQ 3.7 as soon as possible.
-For more information about support for RabbitMQ 3.6,
-see the [RabbitMQ 3.6.x support time line announcement](https://groups.google.com/forum/#!msg/rabbitmq-users/kXkI-f3pgEw/UFowJIK4BQAJ).
-
-If you are already using RabbitMQ for PCF, you can choose to provide service plans
-with RabbitMQ 3.6 for backwards compatibility.
-However, you should also enable RabbitMQ 3.7 plans to allow developers to migrate to the new version.
-
-For new deployments, Pivotal recommends disabling all RabbitMQ 3.6 plans and using
-RabbitMQ 3.7 to avoid the need to upgrade in the near future.
 
 ### <a id="principles"></a> General Principles of the Cluster Plan
 


### PR DESCRIPTION
Can we please remove 3.6 references in 1.13-1.16 docs? These were removed in 1.13. Thanks