### PR TITLE
Added docs for disabling/enabling STOMP plugin in on-demand

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -505,6 +505,7 @@ The following plugins are disabled by default:
 
 * `rabbitmq_event_exchange`---For more information, see the [RabbitMQ documentation](https://www.rabbitmq.com/event-exchange.html).
 * `rabbitmq_mqtt`---For more information, see the [RabbitMQ documentation](https://www.rabbitmq.com/mqtt.html).
+* `rabbitmq_stomp`---For more information, see the [RabbitMQ documentation](https://www.rabbitmq.com/stomp.html).
 * `rabbitmq_amqp1_0`---For more information, see [AMQP 1.0 Plugin](https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.7.15/README.md) in GitHub.
 
 You can enable disabled plugins by doing the following:


### PR DESCRIPTION
STOMP is coming to on-demand only in the unreleased 1.17+, so feel free to merge to master.

[#163418873]