### PR TITLE
1.17.0 known issue

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -161,6 +161,7 @@ This release has the following known issues:
 * Changing the Erlang Cookie value requires cluster downtime and can result in
 failed deployments.
 For more information about this issue, see [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
+* In contrast to other patches of 1.17, you can only upgrade to 1.17.0 from patches within version 1.16 and not from version 1.15. Please, consult Pivotal Network to ensure your upgrade path is supported.
 
 <%= partial './ki-management-ui' %>
 


### PR DESCRIPTION
This is a minor change that we want to add to a previously released patch. We would like to support upgrade from 1.15.* to 1.17.*. However, due to a bug this is not possible for specifically 1.17.0, so we added it as known issue.

Note that in the newly released patch (which is 1.17.1) this is not a problem.

Thanks!
@nodo & @coro 