### PR TITLE
Remove contradiction in 1.16.5 release notes

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -51,8 +51,6 @@ This release has the following known issues:
 failed deployments.
 For more information about this issue, see [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
 
-<%= partial './ki-management-ui' %>
-
 <%= partial 'ki-shareable-instances' %>
 
 ### Compatibility


### PR DESCRIPTION
Removed 'Known Issue' claiming Management UI is still not accessible.

[#168167710]