### PR TITLE
Remove contradiction in 1.17.1 release notes

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -55,8 +55,6 @@ This release has the following known issues:
 * Changing the Erlang Cookie value requires cluster downtime and can result in failed deployments.
 For more information about this issue, see [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
 
-<%= partial './ki-management-ui' %>
-
 ### Compatibility
 
 The following components are compatible with this release:


### PR DESCRIPTION
Removed 'Known Issue' claiming Management UI is still not accessible.

[#168167710]