### PR TITLE
The tile now does not have an upper limit for service instance quota

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -108,7 +108,7 @@ Follow the steps below to configure global settings.
   ![Global Settings Tab](images/global-settings.png)
 1. Configure the following:
 <br><br>
-  * **Service instance quota**  min: 0, max: 200  set the total number of on-demand service instances which can be deployed.
+  * **Service instance quota**: Set the total number of on-demand service instances which can be deployed.
 For more information, see [Setting Limits for On-Demand Service Instances](./set-quotas.html).
 <br><br>
   * **VM options**:


### PR DESCRIPTION
Removed any mention of the limit in our documentation.

This change *only* applies to v1.18 of the tile, and does not need backporting.

Thanks!

cc @gregttn 