### PR TITLE
Add note about regenerating service keys when off-platform is re-enabled

### DIFF
--- a/off-platform-access.html.md.erb
+++ b/off-platform-access.html.md.erb
@@ -56,6 +56,9 @@ Ensure that you review the pre-deployment steps required to enable this feature.
 Pivotal recommends that you change the name or the description of the plan to reflect the new feature.
 ![Service plan pane with the Off-Platform Access checkbox selected.](/images/enable-off-platform.png)
 
+<p class="note"><strong>Note:</strong> If off-platform access is disabled and then re-enabled, application developers will have to create
+new service keys to obtain a new set of credentials for off-platform access.</p>
+
 ## <a id='workflow'></a> Developer Workflow
 
 For instructions for app developers, see [Create a Service Instance with Off-Platform Access](./use.html#off-platform).

--- a/use.html.md.erb
+++ b/use.html.md.erb
@@ -134,6 +134,9 @@ To create a service instance that allows off-platform access:
 The `uri` section of the service key contains the address to the TCP router and a port from the port range.
 You can use this URI to connect to the service instance from outside the foundation.
 
+<p class="note"><strong>Note:</strong> If the operator disables and then re-enables off-platform access on a plan, new service keys
+will have to be created to obtain a new set of credentials for off-platform access.</p>
+
 ## <a id="using-tls"></a> Use Transport Layer Security (TLS)
 
 The operator must enable TLS in the **Security for On-Demand Plans** tab before you can use this feature.


### PR DESCRIPTION
Hey docs, this change applies only to version 1.18 of the RMQ tile docs.

cc @gregttn 