### PR TITLE
1.17.3 release notes - REPLACING 1.17.2 RELEASE NOTES

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -9,23 +9,12 @@ Pivotal recommends upgrading from the latest v1.15 release to the latest v1.17 r
 
 Pivotal discourages any other upgrade path that skips a release, such as v1.14 to v1.16, as they are untested.
 
-Because v1.17 contains a new version of Erlang, upgrading to v1.17 from any previous version requires a
-cluster shutdown. The service is unavailable while the cluster upgrades. After the final node upgrades, the
-cluster starts and the service is available again.
-
 For product versions and upgrade paths,
 see the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matrix.pdf).
 
-## <a id="1172"></a> v1.17.2
+## <a id="1173"></a> v1.17.3
 
 **Release Date**: XXX XX, 2019
-
-<p class="note breaking"><strong>Breaking Change: </strong>
-  Upgrading to RabbitMQ for PCF v1.17 causes app <strong>downtime</strong>.
-This is because the RabbitMQ cluster is taken offline and each node is upgraded to Erlang v21.
-Notify app owners of this expected downtime before you upgrade.
-For more information about downtime during upgrades, see <a href="./upgrade.html#about">About the Upgrade</a>.
-</p>
 
 ### Security Fixes
 
@@ -55,6 +44,9 @@ For more information about RabbitMQ v3.7.18, see the [RabbitMQ Changelog](https:
 ### Features
 
 New features and changes in this release:
+
+* This patch release implements rolling upgrade to migrate RabbitMQ nodes to use Erlang 21. Upgrades from previous minor versions of
+RabbitMQ for PCF to this patch will not require the cluster to be shutdown as part of the upgrade.
 
 * This release updates the following dependencies:
   * OSS RabbitMQ to v3.7.18
@@ -146,9 +138,11 @@ The following components are compatible with this release:
 **Release Date**: August 27, 2019
 
 <p class="note breaking"><strong>Breaking Change: </strong>
-  Upgrading to RabbitMQ for PCF v1.17 causes app <strong>downtime</strong>.
+  Upgrading to RabbitMQ for PCF v1.17.1 causes app <strong>downtime</strong>.
 This is because the RabbitMQ cluster is taken offline and each node is upgraded to Erlang v21.
-Notify app owners of this expected downtime before you upgrade.
+Pivotal recommends upgrading instead to RabbitMQ for PCF v1.17.3 or later. This upgrade path uses rolling upgrade,
+and as such does not involve the cluster being taken offline during the upgrade to Erlang v21.
+
 For more information about downtime during upgrades, see <a href="./upgrade.html#about">About the Upgrade</a>.
 </p>
 
@@ -257,9 +251,11 @@ The following components are compatible with this release:
 **Release Date**: July 18, 2019
 
 <p class="note breaking"><strong>Breaking Change: </strong>
-  Upgrading to RabbitMQ for PCF v1.17 causes app <strong>downtime</strong>.
+  Upgrading to RabbitMQ for PCF v1.17.0 causes app <strong>downtime</strong>.
 This is because the RabbitMQ cluster is taken offline and each node is upgraded to Erlang v21.
-Notify app owners of this expected downtime before you upgrade.
+Pivotal recommends upgrading instead to RabbitMQ for PCF v1.17.3 or later. This upgrade path uses rolling upgrade,
+and as such does not involve the cluster being taken offline during the upgrade to Erlang v21.
+
 For more information about downtime during upgrades, see <a href="./upgrade.html#about">About the Upgrade</a>.
 </p>
 

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -138,7 +138,7 @@ The following components are compatible with this release:
 **Release Date**: August 27, 2019
 
 <p class="note breaking"><strong>Breaking Change: </strong>
-  Upgrading to RabbitMQ for PCF v1.17.1 causes app <strong>downtime</strong>.
+  Upgrading to RabbitMQ for PCF v1.17.1 causes cluster <strong>downtime</strong>.
 This is because the RabbitMQ cluster is taken offline and each node is upgraded to Erlang v21.
 Pivotal recommends upgrading instead to RabbitMQ for PCF v1.17.3 or later. This upgrade path uses rolling upgrade,
 and as such does not involve the cluster being taken offline during the upgrade to Erlang v21.
@@ -251,7 +251,7 @@ The following components are compatible with this release:
 **Release Date**: July 18, 2019
 
 <p class="note breaking"><strong>Breaking Change: </strong>
-  Upgrading to RabbitMQ for PCF v1.17.0 causes app <strong>downtime</strong>.
+  Upgrading to RabbitMQ for PCF v1.17.0 causes cluster <strong>downtime</strong>.
 This is because the RabbitMQ cluster is taken offline and each node is upgraded to Erlang v21.
 Pivotal recommends upgrading instead to RabbitMQ for PCF v1.17.3 or later. This upgrade path uses rolling upgrade,
 and as such does not involve the cluster being taken offline during the upgrade to Erlang v21.


### PR DESCRIPTION
* v1.17.2 will remain unreleased - removed any documentation associated
with it
* v1.17.3 will be released in its stead, at the same time as v1.15.13 &
1.16.6
* Clarified some expectations regarding downtime & cluster shutdown when
upgrading to v1.17.3, vs v1.17.0/v1.17.1.
* 'app downtime' is actually 'cluster downtime'

Please make this live at the same time as 1.15.13 & 1.16.6, once we tell you they are released. 