### PR TITLE
Add note to warn operators about PAS update

### DIFF
--- a/prepare-tls.html.md.erb
+++ b/prepare-tls.html.md.erb
@@ -252,6 +252,8 @@ Click **Security**.
    following the appropriate step below.
     <p class="note warning"><strong>WARNING</strong>: Restarting all of the VMs in your <%= vars.platform_name %> deployment in order to apply a
     CA certificate takes a long time to complete.</p>
+    <p class="note"><strong>Note:</strong>
+    Make sure that when you are on the **Review Pending Changes** page the PAS tile is selected. This will make sure that your new certificate is deployed to all the VMs.</p>
     * **For an Existing Installation**: Complete the steps in
     [Configure Security](install-config.html#security) to enable TLS in the tile,
     click **Review Pending Changes**, and then click **Apply Changes** in the Installation Dashboard.


### PR DESCRIPTION
Can this please be applied to 1.16 and 1.17

Add note to make sure operators are aware of the need to apply changes to PAS when preparing for TLS.

Co-authored-by: David O'Sullivan <daosullivan@pivotal.io>