### PR TITLE
Add release notes for 1.18.2

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -7,9 +7,9 @@ owner: London Services
 
 <%= partial '../../rabbitmq-cf/partials/pcf-name-change' %>
 
-## <a id="1-18-1"></a> v1.18.1
+## <a id="1-18-2"></a> v1.18.2
 
-**Release Date**: December 12, 2019
+**Release Date**: December 17, 2019
 
 ### Features
 
@@ -96,11 +96,11 @@ The following components are compatible with this release:
     </tr>
    <tr>
         <td>loggregator-agent</td>
-        <td>3.21.4</td>
+        <td>3.21.5</td>
     </tr>
    <tr>
         <td>routing</td>
-        <td>0.193.0</td>
+        <td>0.196.0</td>
     </tr>
    <tr>
         <td>syslog</td>


### PR DESCRIPTION
1.18.1 is no longer being released, so remove notes.

We plan on releasing 1.18.2 today; is it possible for this to be merged today? Thanks! :)