### PR TITLE
Clarify docs around Management over TLS for 1.16

### DIFF
--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -57,7 +57,10 @@ rules are set up so that connections are open as described in the table below.
 		<td><strong>ODB</strong></td>
 		<td><strong>Deployed service instances</strong>
 		</td>
-		<td>15672 (RabbitMQ Management UI)</td>
+		<td>
+		  15672 (RabbitMQ Management UI)<br><br>
+		  15671 (RabbitMQ Management UI over TLS)<br><br>
+		</td>
 		<td>This connection is for administrative tasks.<br><br>
 			Avoid opening general use, app-specific ports for this connection.</td>
 	</tr>
@@ -77,8 +80,9 @@ rules are set up so that connections are open as described in the table below.
 		</td>
 		<td>
 				8443 (UAA)<br><br>
-			  8080<br><br>
+				8080<br><br>
 				15672 (RabbitMQ Management UI)<br><br>
+				15671 (RabbitMQ Management UI over TLS)<br><br>
 				5672 (AMQP)<br><br>
 				5671 (AMQPS)<br><br>
 		</td>
@@ -100,6 +104,7 @@ rules are set up so that connections are open as described in the table below.
 		</td>
 		<td>
 				15672 (RabbitMQ Management UI)<br><br>
+				15671 (RabbitMQ Management UI over TLS)<br><br>
 				5672 (AMQP)<br><br>
 				5671 (AMQPS)<br><br>
 				61613 (STOMP)<br><br>

--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -236,9 +236,11 @@ The list defaults to the following:
   * 61614 - STOMP+SSL
   * 15674 - WebSTOMP
 
-* You must leave the management plugin listening on port `15672` and load balance that port.
-
 * If you change the topology of your RabbitMQ cluster, the HAProxy is automatically reconfigured during the deployment.
+
+<p class='note warning'><strong>WARNING</strong>:
+You must leave the management plugin listening on port `15672` and load balance that port.
+</p>
 
 ### <a id="ssl"></a> SSL
 

--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -251,10 +251,12 @@ You must leave the management plugin listening on port `15672` and load balance 
 * SSL is simultaneously provided for AMQPS, STOMP and MQTT.
 No other plugins are automatically configured for use with SSL.
 
-* If you provide SSL keys and certificates, non-SSL support is disabled.
+* If you provide SSL keys and certificates, non-SSL support for AMQP is disabled.
 If you previously deployed this service without SSL support and
-have apps connected to the service, these apps lose
-their connections and must reconnect using SSL.
+have apps connected to the service using AMQP, these apps lose
+their connections and must reconnect using AMQPS. Note that apps
+connected to the cluster over MQTT and STOMP will continue to function
+without SSL.
 
 * SSL settings are applied equally across all VMs in the cluster.
 

--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -238,6 +238,9 @@ The list defaults to the following:
 
 * If you change the topology of your RabbitMQ cluster, the HAProxy is automatically reconfigured during the deployment.
 
+<p class="note"><strong>Note</strong>: Programmatic access to the Management API over HTTPS for the pre-provisioned offerring is not supported.
+As such, there is no need to expose port 15671.</p>
+
 <p class='note warning'><strong>WARNING</strong>:
 You must leave the management plugin listening on port `15672` and load balance that port.
 </p>


### PR DESCRIPTION
We noticed a few things incorrect with our docs. We will cherry-pick to the other supported branches.