### PR TITLE
Add 1.17.5 release notes

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -70,23 +70,23 @@ The following table provides version and version-support information about Rabbi
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>1.17.4</td>
+        <td>1.17.5</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 22, 2019</td>
+        <td>January 9, 2020</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>RabbitMQ OSS 3.7.21</td>
+        <td>RabbitMQ OSS 3.7.22</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.4, 2.5, 2.6, and 2.7</td>
+        <td>2.5, 2.6, 2.7, and 2.8</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service version(s)</td>
-        <td>2.4, 2.5, 2.6, and 2.7</td>
+        <td>2.5, 2.6, 2.7, and 2.8</td>
     </tr>
     <tr>
         <td>IaaS support</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -17,6 +17,106 @@ However, upgrading to v1.17.2 and earlier still requires a cluster shutdown.
 For product versions and upgrade paths,
 see the [Product Compatibility Matrix](http://docs.pivotal.io/compatibility-matrix.pdf).
 
+## <a id="1-17-5"></a> v1.17.5
+
+**Release Date**: January 9, 2020
+
+### Bug Fixes
+
+This release includes the following bug fixes:
+
+* Upgrading from 1.15.x with TLS set to optional, to this patch, no longer fails. This is the case for v1.17.4 of the tile.
+Please upgrade to this version or later to avoid the bug.
+
+### Features
+
+New features and changes in this release:
+
+* This release updates the following dependencies:
+	* OSS RabbitMQ to <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.22">v3.7.22</a>
+	* Erlang to v21.3.8.11
+	* HAProxy to v1.8.23
+
+### Known Issues
+
+This release has the following known issue:
+
+* Changing the Erlang Cookie value requires cluster downtime and can result in failed deployments.
+For more information about this issue, see [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table class="nice">
+    <th>Component</th>
+    <th>Version</th>
+    <tr>
+        <td>Stemcell</td>
+        <td>315.x</td>
+    </tr>
+    <tr>
+        <td>PCF</td>
+        <td>v2.5.x, v2.6.x, v2.7.x and v2.8.x</td>
+    </tr>
+    <tr>
+        <td>OSS RabbitMQ</td>
+        <td><a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.22">v3.7.22</a></td>
+    </tr>
+    <tr>
+        <td>Erlang</td>
+        <td>21.3.8.11</td>
+    </tr>
+    <tr>
+        <td>HAProxy</td>
+        <td>1.8.23</td>
+    </tr>
+    <tr>
+        <td>bpm</td>
+        <td>1.1.6</td>
+    </tr>
+    <tr>
+        <td>service-metrics</td>
+        <td>1.12.5</td>
+    </tr>
+    <tr>
+        <td>on-demand-service-broker</td>
+        <td>0.36.0</td>
+    </tr>
+    <tr>
+        <td>rabbitmq-metrics</td>
+        <td>22.0.0</td>
+    </tr>
+   <tr>
+        <td>rabbitmq-on-demand-adapter</td>
+        <td>111.0.0</td>
+    </tr>
+   <tr>
+        <td>cf-rabbitmq-multitenant-broker</td>
+        <td>61.0.0</td>
+    </tr>
+   <tr>
+        <td>loggregator-agent</td>
+        <td>3.21.5</td>
+    </tr>
+   <tr>
+        <td>routing</td>
+        <td>0.196.0</td>
+    </tr>
+   <tr>
+        <td>syslog</td>
+        <td>11.6.1</td>
+    </tr>
+   <tr>
+        <td>cf-rabbitmq-smoke-tests</td>
+        <td>40.0.0</td>
+    </tr>
+   <tr>
+        <td>cf-rabbitmq</td>
+        <td>283.0.0</td>
+    </tr>
+</table>
+
 ## <a id="1-17-4"></a> v1.17.4
 
 **Release Date**: November 22, 2019
@@ -45,6 +145,8 @@ New features and changes in this release:
 ### Known Issues
 
 This release has the following known issue:
+
+* <b>Upgrading to this patch version from 1.15.x when TLS is enabled, fails the upgrade. This issue is fixed in the next patch release.</b>
 
 * Changing the Erlang Cookie value requires cluster downtime and can result in failed deployments.
 For more information about this issue, see [Changing the Erlang Cookie Value Known Issue](./install-config-pp.html#changing-issue).


### PR DESCRIPTION
Please do not publish the docs yet.

Also, please note that PAS compatibility for 2.4 has been removed, and 2.8 has been added! Please could you update the compatibility matrix to reflect the same?

Thank you!