### PR TITLE
1.18.5 release notes - Cluster name change

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -145,7 +145,8 @@ This release fixes the following issues:
 	effects. It regenerates all variables associated with a deployment,
 	even those that are specified in a runtime config, causing downtime
 	and other unexpected behavior.
-
+* The RabbitMQ cluster name now matches its service instance GUID rather than default `rabbit@localhost`,
+  enabling operators to filter metrics by cluster names.
 
 ### Known Issues
 


### PR DESCRIPTION
We missed mentioning this change. This issue was fixed in 1.18.5, this needs to be deployed to prod. 