### PR TITLE
Add cluster_name queue issue to known_issues

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -157,6 +157,8 @@ This release has the following known issues:
 <%= partial vars.path_to_partials + "/rabbitmq/ki-health-check-time-out" %>
 <%= partial vars.path_to_partials + "/rabbitmq/ki-ha-sync-mode-timeout" %>
 
+* The RabbitMQ cluster name matches its service instance GUID rather than the default value `rabbit@localhost`.
+  This leads to potential issue with federated queues being recreated with a new cluster name.
 
 ### Compatibility
 


### PR DESCRIPTION
[#173565338]

Co-authored-by: Grzegorz Tatarzyn <gtatarzyn@pivotal.io>

This known_issue should also be added to 1.18.6 and 1.19.0
