### PR TITLE
Update valid RabbitMQ Tags

### DIFF
--- a/enable-oauth.html.md.erb
+++ b/enable-oauth.html.md.erb
@@ -88,13 +88,13 @@ To create a UAA group for a space:
 
     Where:
     * `SPACE-GUID` is the space GUID.
-    * `RABBITMQ-TAG` is a RabbitMQ tag of your choice that dictates what the user is permitted to do.
+    * `RABBITMQ-TAG` must be either `monitoring` or `administrator`. The RabbitMQ tag dictates what the user is permitted to do.
     For more information about the RabbitMQ tags, see the
     [RabbitMQ documentation](https://www.rabbitmq.com/management.html#permissions).
 
     For example:
     <pre class="terminal">
-    $ uaac group add p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:policymaker
+    $ uaac group add p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:monitoring
     </pre>
 
 The on-demand broker creates a separate UAA client with scope `p-rabbitmq_SPACE-GUID` for every
@@ -119,7 +119,7 @@ command for every RabbitMQ UAA group:
     ```
 
     Where:
-    * `RABBITMQ-UAA-GROUP` is the UAA group name created above. For example: `p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:policymaker`
+    * `RABBITMQ-UAA-GROUP` is the UAA group name created above. For example: `p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:monitoring`
     * `GROUP-DISTINGUISHED-NAME` is the name of the LDAP group.
 
 - Add UAA members to UAA groups by running:
@@ -129,7 +129,7 @@ command for every RabbitMQ UAA group:
     ```
 
     Where:
-    * `RABBITMQ-UAA-GROUP` is the UAA group name created above. For example, `p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:policymaker`
+    * `RABBITMQ-UAA-GROUP` is the UAA group name created above. For example, `p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:monitoring`
     * `USERNAME` is a UAA group member. For example, a CF user.
 
 
@@ -146,3 +146,5 @@ checkbox are selected.](/images/enable-oauth.png)
 1. Click **Save**.
 1. Go back to **<%= vars.ops_manager %> Installation Dashboard &gt; Review Pending Changes**.
 1. Click **Apply Changes** to apply the changes to the <%= vars.product_short %> tile.
+
+Enabling OAuth will neither change the behaviour of service keys, nor remove users from the internal backend of existing RMQ instances.


### PR DESCRIPTION
The UAA group must contain either the RabbitMQ tag `monitoring` or `administrator`.

Also, add a warning that enabling OAuth does not enforce OAuth.

[#174005628]
