### PR TITLE
Add JWT signing key rotation warning

### DIFF
--- a/enable-oauth.html.md.erb
+++ b/enable-oauth.html.md.erb
@@ -151,3 +151,7 @@ checkbox for enabling OAuth, and a Save button. The 'Not Configured' radio butto
 1. Click **Save**.
 1. Go back to **<%= vars.ops_manager %> Installation Dashboard &gt; Review Pending Changes**.
 1. Click **Apply Changes** to apply the changes to the <%= vars.product_short %> tile.
+
+<p class="note warning">
+  <strong>Warning:</strong> JSON Web Token (JWT) signing key rotation via the UAA API is not supported.
+</p>


### PR DESCRIPTION
Rotating the JWT signing key directly via the UAA API as described in https://docs.cloudfoundry.org/api/uaa/version/74.23.0/index.html#updating-an-identity-zone is currently not supported.

Should this be merged to any other branches?
No.

See also https://www.pivotaltracker.com/story/show/173607084