### PR TITLE
Correct version numbers in release notes.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -52,7 +52,7 @@ The following components are compatible with this release:
 
 <table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
 		<td>Erlang</td>
-		<td>22.3.3</td>
+		<td>22.3.4</td>
 	</tr>
 	<tr>
 		<td>HAProxy</td>
@@ -60,7 +60,7 @@ The following components are compatible with this release:
 	</tr>
 	<tr>
 		<td>OSS RabbitMQ*</td>
-		<td>3.8.3</td>
+		<td>3.8.5</td>
 	</tr>
 	<tr>
 		<td>Stemcell</td>
@@ -76,23 +76,23 @@ The following components are compatible with this release:
 	</tr>
 	<tr>
 		<td>cf-cli</td>
-		<td>1.26.0</td>
+		<td>1.27.0</td>
 	</tr>
 	<tr>
 		<td>cf-rabbitmq</td>
-		<td>292.0.0</td>
+		<td>312.0.0</td>
 	</tr>
 	<tr>
 		<td>cf-rabbitmq-multitenant-broker</td>
-		<td>66.0.0</td>
+		<td>73.0.0</td>
 	</tr>
 	<tr>
 		<td>cf-rabbitmq-service-gateway</td>
-		<td>11.0.0</td>
+		<td>18.0.0</td>
 	</tr>
 	<tr>
 		<td>cf-rabbitmq-smoke-tests</td>
-		<td>46.0.0</td>
+		<td>55.0.0</td>
 	</tr>
 	<tr>
 		<td>loggregator-agent</td>
@@ -100,27 +100,23 @@ The following components are compatible with this release:
 	</tr>
 	<tr>
 		<td>on-demand-service-broker</td>
-		<td>0.39.0</td>
+		<td>0.40.0</td>
 	</tr>
 	<tr>
 		<td>rabbitmq-metrics</td>
-		<td>25.0.0</td>
+		<td>34.0.0</td>
 	</tr>
 	<tr>
 		<td>rabbitmq-on-demand-adapter</td>
-		<td>119.0.0</td>
+		<td>139.0.0</td>
 	</tr>
 	<tr>
 		<td>routing</td>
-		<td>0.200.0</td>
+		<td>0.203.0</td>
 	</tr>
 	<tr>
 		<td>service-metrics</td>
 		<td>1.12.5</td>
-	</tr>
-	<tr>
-		<td>syslog</td>
-		<td>11.6.1</td>
 	</tr></table>
 
 <sup>*</sup> For more information, see the


### PR DESCRIPTION
Hi docs! 

The release notes for 1.20.0 ended up listing incorrect version numbers and this is causing our customers confusion. If we could get these new docs live, we would appreciate it. 

Thanks,
Mirah
