### PR TITLE
Fix Distinguished Name description

### DIFF
--- a/enable-oauth.html.md.erb
+++ b/enable-oauth.html.md.erb
@@ -136,7 +136,7 @@ command for every RabbitMQ UAA group:
 
     Where:
     * `RABBITMQ-UAA-GROUP` is the UAA group name created above. For example: `p-rabbitmq_64bd9d4d-d2c8-4207-bb76-91a245e67d9d.tag:monitoring`
-    * `GROUP-DISTINGUISHED-NAME` is the name of the LDAP group.
+    * `GROUP-DISTINGUISHED-NAME` is the Distinguished Name (DN) of the LDAP group. For example `ou=operators,dc=example,dc=com`
 
 - Add UAA members to UAA groups by running:
 


### PR DESCRIPTION
Should this be merged to any other branches?
Yes, to 1.20 please

Having the group name only (instead of DN) results in `Login failed`.