### PR TITLE
Rename cf-rabbitmq-service-gateway-release to cf-service-gateway-release

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -101,7 +101,7 @@ The following components are compatible with this release:
 		<td>78.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>28.0.0</td>
 	</tr>
 	<tr>
@@ -220,7 +220,7 @@ The following components are compatible with this release:
 		<td>73.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>18.0.0</td>
 	</tr>
 	<tr>
@@ -330,7 +330,7 @@ The following components are compatible with this release:
 		<td>69.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>13.0.0</td>
 	</tr>
 	<tr>
@@ -449,7 +449,7 @@ The following components are compatible with this release:
 		<td>65.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>10.0.0</td>
 	</tr>
 	<tr>
@@ -593,7 +593,7 @@ The following components are compatible with this release:
         <td>115.0.0</td>
     </tr>
    <tr>
-        <td>cf-rabbitmq-service-gateway</td>
+        <td>cf-service-gateway</td>
         <td>9.0.0</td>
     </tr>
    <tr>
@@ -702,7 +702,7 @@ The following components are compatible with this release:
         <td>0.36.0</td>
     </tr>
    <tr>
-        <td>cf-rabbitmq-service-gateway</td>
+        <td>cf-service-gateway</td>
         <td>4.0.0</td>
     </tr>
     <tr>
@@ -820,7 +820,7 @@ The following components are compatible with this release:
         <td>0.36.0</td>
     </tr>
    <tr>
-        <td>cf-rabbitmq-service-gateway</td>
+        <td>cf-service-gateway</td>
         <td>4.0.0</td>
     </tr>
     <tr>
@@ -856,7 +856,7 @@ The following components are compatible with this release:
         <td>283.0.0</td>
     </tr>
     <tr>
-        <td>cf-rabbitmq-service-gateway</td>
+        <td>cf-service-gateway</td>
         <td>4.0.0</td>
     </tr>
 </table>


### PR DESCRIPTION
The git source code repository has already been renamed

Tanzu RabbitMQ for VMs story reference: https://www.pivotaltracker.com/story/show/175198324
