### PR TITLE
Rename cf-rabbitmq-service-gateway-release to cf-service-gateway-release

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -72,7 +72,7 @@ The following components are compatible with this release:
 		<td>78.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>28.0.0</td>
 	</tr>
 	<tr>
@@ -195,7 +195,7 @@ The following components are compatible with this release:
 		<td>73.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>18.0.0</td>
 	</tr>
 	<tr>
@@ -307,7 +307,7 @@ The following components are compatible with this release:
 		<td>69.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>13.0.0</td>
 	</tr>
 	<tr>
@@ -434,7 +434,7 @@ The following components are compatible with this release:
 		<td>66.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>11.0.0</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
The git source code repository has already been renamed

Tanzu RabbitMQ for VMs story reference: https://www.pivotaltracker.com/story/show/175198324
