### PR TITLE
Rename cf-rabbitmq-service-gateway-release to cf-service-gateway-release

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -75,7 +75,7 @@ The following components are compatible with this release:
 		<td>78.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>28.0.0</td>
 	</tr>
 	<tr>
@@ -197,7 +197,7 @@ The following components are compatible with this release:
 		<td>73.0.0</td>
 	</tr>
 	<tr>
-		<td>cf-rabbitmq-service-gateway</td>
+		<td>cf-service-gateway</td>
 		<td>18.0.0</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
The git source code repository has already been renamed

Tanzu RabbitMQ for VMs story reference: https://www.pivotaltracker.com/story/show/175198324
