### PR TITLE
Web STOMP support in 1.21

### DIFF
--- a/about.html.md.erb
+++ b/about.html.md.erb
@@ -115,6 +115,8 @@ rules are set up so that connections are open as described in the table below.
 				5671 (AMQPS)<br><br>
 				61613 (STOMP)<br><br>
 				61614 (STOMPS)<br><br>
+				15674 (Web STOMP)<br><br>
+				15673 (Web STOMPS)<br><br>
 				1883 (MQTT)<br><br>
 				8883 (MQTTS)<br><br>
 		</td>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -127,7 +127,7 @@ For more information, see [Unlocking the Power of On-Demand <%= vars.product_ful
 * Bind apps to an instance of the plan, providing unique credentials for each binding
 * Management UI access to operators and app developers
 * Deployment across multiple AZs, with nodes striped across the AZs automatically
-* Enable SSL (Secure Sockets Layer) for the AMQP, MQTT, STOMP protocols
+* Enable SSL (Secure Sockets Layer) for the AMQP, MQTT, STOMP, Web STOMP protocols
 * HA Proxy load balancer across all nodes to balance connections
 * Plugin configuration can be easily changed at any time and the cluster redeployed and updated
 * The cluster topology can be changed and easily scaled out

--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -847,6 +847,7 @@ The following plugins are disabled by default:
 * `rabbitmq_event_exchange`: For more information, see the [Event Exchange Plugin](https://www.rabbitmq.com/event-exchange.html) in the RabbitMQ documentation.
 * `rabbitmq_mqtt`: For more information, see the [MQTT Plugin](https://www.rabbitmq.com/mqtt.html) in the RabbitMQ documentation.
 * `rabbitmq_stomp`: For more information, see [STOMP Plugin](https://www.rabbitmq.com/stomp.html) in the RabbitMQ documentation.
+* `rabbitmq_web_stomp`: For more information, see [Web STOMP Plugin](https://www.rabbitmq.com/web-stomp.html) in the RabbitMQ documentation.
 * `rabbitmq_amqp1_0`: For more information, see [AMQP 1.0 Plugin](https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.8.0/README.md) in GitHub.
 
 To enable disabled plugins:

--- a/reference.html.md.erb
+++ b/reference.html.md.erb
@@ -85,6 +85,7 @@ Adding and removing the following plugins require bound apps to be restaged:
 
 * rabbitmq_management
 * rabbitmq_stomp
+* rabbitmq_web_stomp
 * rabbitmq_mqtt
 * rabbitmq\_amqp1\_0
 

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -13,8 +13,7 @@ owner: London Services
 
 New features and changes in this release:
 
-* **Run-in heading:**
-
+* RabbitMQ Web STOMP plugin can now be enabled for on-demand instances. It can be used with TLS and Service Gateway.
 
 ### Known Issues
 

--- a/service-gateway-access.html.md.erb
+++ b/service-gateway-access.html.md.erb
@@ -15,7 +15,7 @@ For related procedures, see:
 <p class="note">
   <strong>Note:</strong> Service-Gateway access is no longer in the beta stage. It works with Advanced Message
   Queuing Protocol (AMQP), MQ Telemetry Transport (MQTT), Simple (or Streaming) Text Orientated Messaging
-  Protocol (STOMP), and AMQP 1.0.
+  Protocol (STOMP), STOMP over a WebSocket connection (Web STOMP), and AMQP 1.0.
 </p>
 
 

--- a/vcap-services.html.md.erb
+++ b/vcap-services.html.md.erb
@@ -89,6 +89,7 @@ If you adjust the plugins and protocols enabled for RabbitMQ, you may need to fo
 
 * rabbitmq_management
 * rabbitmq_stomp
+* rabbitmq_web_stomp
 * rabbitmq_mqtt
 * rabbitmq\_amqp1\_0
 


### PR DESCRIPTION
[#175286350]

Which other branches should this be merged with (if any)?

None. This is a 1.21 feature.