### PR TITLE
Change wording around prometheus plugin

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -356,14 +356,13 @@ The following KPIs from the RabbitMQ server component:
 
 ### <a id="prometheus"></a> Enable the Prometheus Plugin
 
-<%= vars.product_short %> supports enabling the `rabbitmq_prometheus` plugin for on-demand instances.
+<%= vars.product_short %> enables the `rabbitmq_prometheus` plugin for on-demand instances.
 For more information about the plugin and monitoring RabbitMQ using Prometheus and Grafana, see the
 [RabbitMQ documentation](https://www.rabbitmq.com/prometheus.html).
 For a list of plugins that can be enabled for on-demand instances, see
 [RabbitMQ Server Plugins](./install-config.html#server-plugins).
 
-Enabling the plugin causes Prometheus-style metrics to be emitted at
-`SERVICE-INSTANCE-ID:15692/metrics`.
+Prometheus-style metrics are available at `SERVICE-INSTANCE-ID:15692/metrics`.
 To pull these metrics from the service instances, you must configure a Prometheus instance.
 If Prometheus is deployed in the environment, use the following scrape configuration in
 the Prometheus config file to discover RabbitMQ instances:

--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -354,7 +354,7 @@ The following KPIs from the RabbitMQ server component:
 </table>
 
 
-### <a id="prometheus"></a> Enable the Prometheus Plugin
+### <a id="prometheus"></a> Prometheus Plugin
 
 <%= vars.product_short %> enables the `rabbitmq_prometheus` plugin for on-demand instances.
 For more information about the plugin and monitoring RabbitMQ using Prometheus and Grafana, see the


### PR DESCRIPTION
We don't "supporting enabling" the prometheus plugin - since 1.19 we always enable it and don't allow to disable it.

Please backport to 1.20 and 1.19.

Which other branches should this be merged with (if any)?
