### PR TITLE
Add documentation for configuring Prometheus via Healthwatch v2.

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -364,8 +364,8 @@ For the list of enabled plugins for on-demand instances, see
 
 Prometheus-style metrics are available at `SERVICE-INSTANCE-ID:15692/metrics`.
 To pull these metrics from the service instances, you must configure a Prometheus instance.
-If Prometheus is deployed in the environment, use the following scrape configuration in
-the Prometheus config file to discover RabbitMQ instances:
+If Prometheus is deployed in the environment, for example, via the Healthwatch v2 tile,
+use the following scrape configuration in the Prometheus config file to discover RabbitMQ instances:
 
 ```
 job_name: rabbitmq
@@ -380,11 +380,14 @@ dns_sd_configs:
 ```
 
 The regular expression in the scrape config name ensures that Prometheus discovers all future service
-instances.
+instances. If Prometheus is deployed via the Healthwatch v2 tile, this config should be added to the
+["additional scrape config" property](https://docs.pivotal.io/healthwatch/2-0/federation.html).
 
 The RabbitMQ team has written pre-set Grafana dashboards that you can import into Grafana.
 For more information about these dashboards, see the
-[RabbitMQ documentation](https://www.rabbitmq.com/prometheus.html).
+[RabbitMQ documentation](https://www.rabbitmq.com/prometheus.html). If Grafana is deployed using the
+Healthwatch v2 tile, these dashboards can be loaded by selecting the "Enable RabbitMQ dashboards"
+checkbox in the Healthwatch tile.
 
 
 ### <a id="bosh"></a> BOSH System Health Metrics


### PR DESCRIPTION
Hi docs, this PR is to document the Healthwatch v2 Prometheus and Grafana integration. 

Please cherry-pick this back to 1.19 and 1.20. 

Thanks!
