### PR TITLE
Add OAuth for apps to release notes

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -17,6 +17,10 @@ New features and changes in this release:
 You can enable this plugin for on-demand instances including instances with TLS
 and service-gateway.
 
+* **OAuth for apps:**
+Applications can now authenticate with RabbitMQ using the OAuth client flow.
+For more information, see [Enabling OAuth for apps](./enable-oauth-for-apps.html).
+
 * **Option to enforce OAuth for on-demand instances:**
 When OAuth is enforced, the tile does not return RabbitMQ user credentials
 in the binding, making OAuth the only source for application authentication and authorization.


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
Only into 1.21