### PR TITLE
Add direct reply-to feature to known issues

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -56,6 +56,9 @@ components over mutual TLS.
 This release has the following issue:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+- **Direct reply-to feature:**
+For on-demand service instances created in v1.20.0 - v1.20.3 and v1.21.0,
+the [direct reply-to feature](https://www.rabbitmq.com/direct-reply-to.html) is not supported.
 
 ### Compatibility
 


### PR DESCRIPTION
The direct reply-to feature is not supported because the RabbitMQ node names
for on-demand service instances created in >v1.20.0 use long node names.
The long node name includes the BOSH DNS name which comprises
around 150 characters depending on the environment since it includes 2
GUIDS.
The direct reply-to feature creates an Erlang atom which is longer than
the max atom limit of 255 characters since it base 64 encodes the already
long DNS name and adds more characters to it. See https://github.com/rabbitmq/rabbitmq-server/blob/4f43f393bf85e5cd373c84660cc07700fa731e72/deps/rabbit/src/rabbit_channel.erl#L1387-L1393.

Which other branches should this be merged with (if any)?
* Needs to be added to 1.20.0 - 1.20.3 release notes as well.
