### PR TITLE
Update pre-stop commands

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -515,8 +515,8 @@ plan.
         <td><strong>Wait for Queue Synchronization</strong></td>
         <td>Select this checkbox to enable the following pre-stop checks:
           <ul>
-            <li><code>rabbitmq-diagnostics check\_if\_node\_is\_mirror\_sync\_critical</code></li>
-            <li><code>rabbitmq-diagnostics check\_if\_node\_is\_quorum\_critical</code></li>
+            <li><code>rabbitmq-upgrade await\_online\_quorum\_plus\_one --timeout 3600</code></li>
+            <li><code>rabbitmq-upgrade await\_online\_synchronized\_mirror --timeout 3600/code></li>
           </ul>
           Enabling these checks ensures that queues are synced before an upgrade.
           <p class="note">


### PR DESCRIPTION
since they changed in https://github.com/pivotal-cf/cf-rabbitmq-release/commit/381c08e107d86bff4a250d47aa40cf1d8a1c27c1#diff-9e30d052c2d5adb5805d5787855ac511c89cfaac75f28320a90203f438808fd8

Which other branches should this be merged with (if any)?
1.21, 1.20, 1.19, 1.18