### PR TITLE
Allow tier-1 plugins to be enabled in on-demand in v2.x

### DIFF
--- a/install-config.html.md.erb
+++ b/install-config.html.md.erb
@@ -877,11 +877,21 @@ GitHub.
 
 The following plugins are disabled by default:
 
+* `rabbitmq_amqp1_0`: For more information, see the [AMQP 1.0 Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_amqp1_0/README.md) in GitHub.
+* `rabbitmq_auth_backend_cache`: For more information, see the [Auth Backend Cache Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_auth_backend_cache/README.md) in GitHub.
+* `rabbitmq_auth_backend_http`: For more information, see the [Auth Backend HTTP Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_auth_backend_http/README.md) in GitHub.
+* `rabbitmq_auth_backend_ldap`: For more information, see the [LDAP Plugin](https://www.rabbitmq.com/ldap.html) in the RabbitMQ documentation.
+* `rabbitmq_auth_mechanism_ssl`: For more information, see the [Auth Mechanism SSL Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_auth_mechanism_ssl/README.md) in GitHub.
 * `rabbitmq_event_exchange`: For more information, see the [Event Exchange Plugin](https://www.rabbitmq.com/event-exchange.html) in the RabbitMQ documentation.
+* `rabbitmq_jms_topic_exchange`: For more information, see the [JMS Topic Exchange Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_jms_topic_exchange/README.md) in the RabbitMQ documentation.
 * `rabbitmq_mqtt`: For more information, see the [MQTT Plugin](https://www.rabbitmq.com/mqtt.html) in the RabbitMQ documentation.
-* `rabbitmq_stomp`: For more information, see [STOMP Plugin](https://www.rabbitmq.com/stomp.html) in the RabbitMQ documentation.
-* `rabbitmq_web_stomp`: For more information, see [Web STOMP Plugin](https://www.rabbitmq.com/web-stomp.html) in the RabbitMQ documentation.
-* `rabbitmq_amqp1_0`: For more information, see [AMQP 1.0 Plugin](https://github.com/rabbitmq/rabbitmq-amqp1.0/blob/v3.8.0/README.md) in GitHub.
+* `rabbitmq_stomp`: For more information, see the [STOMP Plugin](https://www.rabbitmq.com/stomp.html) in the RabbitMQ documentation.
+* `rabbitmq_tracing`: For more information, see the [Tracing Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_tracing/README.md) in GitHub.
+* `rabbitmq_trust_store`: For more information, see the [Trust Store Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_trust_store/README.md) in GitHub.
+* `rabbitmq_web_mqtt`: For more information, see the [Web MQTT Plugin](https://www.rabbitmq.com/web-mqtt.html) in the RabbitMQ documentation.
+* `rabbitmq_web_mqtt_examples`: For more information, see the [Web MQTT Examples Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_web_mqtt_examples/README.md) in GitHub.
+* `rabbitmq_web_stomp`: For more information, see the [Web STOMP Plugin](https://www.rabbitmq.com/web-stomp.html) in the RabbitMQ documentation.
+* `rabbitmq_web_stomp_examples`: For more information, see the [Web STOMP Examples Plugin](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_web_stomp_examples/README.md) in GitHub.
 
 To enable disabled plugins:
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
None. This will be only relevant for v2.x