### PR TITLE
Fix Title generation in Expert mode doc

### DIFF
--- a/expert-override-config.html.md.erb
+++ b/expert-override-config.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Expert mode: Overriding RabbitMQ Server configuration
+title: Expert mode - Overriding RabbitMQ Server configuration
 owner: RabbitMQ
 ---
 


### PR DESCRIPTION
The extra colon I believe is causing the title to fail to render in the staging env. This allows the title to be rendered correctly.

This only needs to go into master, for the 2.0 release.