### PR TITLE
1.20: Clarification about non-SSL protocols when TLS enabled

### DIFF
--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -292,10 +292,9 @@ the deployment.
 If you provide a certificate, SSL is simultaneously provided for AMQPS, STOMP, and MQTT.
 No other plugins are automatically configured for use with SSL.
 
-If you provide SSL keys and certificates, non-SSL support for AMQP is disabled.
-If you previously deployed this service without SSL support and have apps connected to the service
-using AMQP, these apps lose their connections and must reconnect using AMQPS.
-Apps connected to the cluster over MQTT and STOMP continue to function without SSL.
+By default, apps connected to the cluster over AMQP, MQTT and STOMP continue to function without SSL.
+To restrict apps to only connect over secure protocols, see [Configure TLS Support](#tls) below.
+
 SSL settings are applied equally across all VMs in the cluster.
 
 You can provide more then one CA certificate.


### PR DESCRIPTION
The latest patches allowed AMQP to still be accessible when TLS is
enabled, by default.

This should be merged to 1.20 and made live, as it affects the recently-released patches.