### PR TITLE
Add release notes for v2.0.1

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -5,6 +5,100 @@ owner: London Services
 
 <%= partial vars.path_to_partials + '/upgrade-planner' %>
 
+## <a id="2-0-1"></a> v2.0.1
+
+**Release Date**: May 21, 2021
+
+### Resolved Issues
+
+This release fixes the following issues:
+
+* **Bumped RabbitMQ to v3.8.16:**
+  RabbitMQ v3.8.15 addresses two CVEs.
+
+
+### Known Issues
+
+This release has the following issues:
+
+<%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
+		<td>Erlang</td>
+		<td>23.3.2</td>
+	</tr>
+	<tr>
+		<td>HAProxy</td>
+		<td>1.8.30</td>
+	</tr>
+	<tr>
+		<td>OSS RabbitMQ*</td>
+		<td>3.8.16</td>
+	</tr>
+	<tr>
+		<td>Stemcell</td>
+		<td>621.x</td>
+	</tr>
+	<tr>
+		<td>Tanzu Application Service</td>
+		<td>2.7.*, 2.8.*, 2.9.*, 2.10.*, 2.11.*</td>
+	</tr>
+	<tr>
+		<td>bpm</td>
+		<td>1.1.9</td>
+	</tr>
+	<tr>
+		<td>cf-cli</td>
+		<td>1.32.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq</td>
+		<td>372.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-multitenant-broker</td>
+		<td>94.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-smoke-tests</td>
+		<td>98.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-service-gateway</td>
+		<td>50.0.0</td>
+	</tr>
+	<tr>
+		<td>loggregator-agent</td>
+		<td>6.2.0</td>
+	</tr>
+	<tr>
+		<td>on-demand-service-broker</td>
+		<td>0.41.1</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-metrics</td>
+		<td>56.0.0</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-on-demand-adapter</td>
+		<td>175.0.0</td>
+	</tr>
+	<tr>
+		<td>routing</td>
+		<td>0.213.0</td>
+	</tr>
+	<tr>
+		<td>service-metrics</td>
+		<td>2.0.13</td>
+	</tr></table>
+
+* For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16">v3.8.16</a> GitHub documentation.
+
 ## <a id="2-0-0"></a> v2.0.0
 
 **Release Date**: April 14, 2021


### PR DESCRIPTION
We bump RabbitMQ since CVEs are addressed.
See https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.15 for more information.

Which other branches should this be merged with (if any)?
None
