### PR TITLE
Direct reply to is supported in 1.21.3

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -21,10 +21,9 @@ Maintenance change in this release:
 
 ### Known Issues
 
-This release has the following issues:
+This release has the following issue:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
-<%= partial vars.path_to_partials + "/rabbitmq/ki-direct-reply-to" %>
 
 
 ### Compatibility
@@ -98,9 +97,12 @@ The following components are compatible with this release:
   <tr>
     <td>service-metrics</td>
     <td>1.12.5</td>
-  </tr></table>
+  </tr>
+</table>
 
-<sup>*</sup> For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16">v3.8.16</a> GitHub documentation.
+<sup>*</sup> For more information, see the
+<a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16">v3.8.16</a> GitHub
+documentation.
 
 ## <a id="1-21-2"></a> v1.21.2
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?
1.21. Remove the warning about direct reply to in `1.21.3` release note as it is supported in this release.