### PR TITLE
Add 2.0.2 release notes

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -76,11 +76,11 @@ The following table provides version and version-support information about <%= v
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>2.0.1</td>
+        <td>2.0.2</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>May 21, 2021</td>
+        <td>May 26, 2021</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -5,6 +5,96 @@ owner: London Services
 
 <%= partial vars.path_to_partials + '/upgrade-planner' %>
 
+## <a id="2-0-2"></a> v2.0.2
+
+**Release Date**: May 26, 2021
+
+### Security fixes
+
+This release contains a fix to the following security issues:
+* CVE-2021-30465
+
+### Known Issues
+
+This release has the following issue:
+
+<%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
+		<td>Erlang</td>
+		<td>23.3.4</td>
+	</tr>
+	<tr>
+		<td>HAProxy</td>
+		<td>1.8.30</td>
+	</tr>
+	<tr>
+		<td>OSS RabbitMQ*</td>
+		<td>3.8.16</td>
+	</tr>
+	<tr>
+		<td>Stemcell</td>
+		<td>621.x</td>
+	</tr>
+	<tr>
+		<td>Tanzu Application Service</td>
+    <td>2.7.x, 2.8.x, 2.9.x, 2.10.x, and 2.11.x</td>
+	</tr>
+	<tr>
+		<td>bpm</td>
+		<td>1.1.11</td>
+	</tr>
+	<tr>
+		<td>cf-cli</td>
+		<td>1.32.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq</td>
+		<td>375.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-multitenant-broker</td>
+		<td>95.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-smoke-tests</td>
+		<td>101.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-service-gateway</td>
+		<td>50.0.0</td>
+	</tr>
+	<tr>
+		<td>loggregator-agent</td>
+		<td>6.2.1</td>
+	</tr>
+	<tr>
+		<td>on-demand-service-broker</td>
+		<td>0.41.1</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-metrics</td>
+		<td>58.0.0</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-on-demand-adapter</td>
+		<td>176.0.0</td>
+	</tr>
+	<tr>
+		<td>routing</td>
+		<td>0.213.0</td>
+	</tr>
+	<tr>
+		<td>service-metrics</td>
+		<td>2.0.13</td>
+	</tr></table>
+
+* For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16">v3.8.16</a> GitHub documentation.
+#
 ## <a id="2-0-1"></a> v2.0.1
 
 **Release Date**: May 21, 2021
@@ -22,7 +112,7 @@ Maintenance change in this release:
 This release has the following issue:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
-
+* This release does not contain the fix to CVE-2021-30465. VMware advises upgrading to v2.0.2 or later.
 
 ### Compatibility
 
@@ -152,6 +242,7 @@ For more information, see
 This release has the following issues:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+* This release does not contain the fix to CVE-2021-30465. VMware advises upgrading to v2.0.2 or later.
 
 ### Compatibility
 


### PR DESCRIPTION
Here are the release notes for the 2.0.2 security patch, to be released at the same time as #600 .

Thanks!