### PR TITLE
Fix indentation in monitoring

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -339,9 +339,9 @@ metrics_path: "/metrics"
 scheme: http
 dns_sd_configs:
 - names:
-   - q-s4.rabbitmq-server.*.*.bosh.
-    type: A
-     port: 15692
+    - q-s4.rabbitmq-server.*.*.bosh.
+  type: A
+  port: 15692
 ```
 
 The regular expression in the scrape config name ensures that Prometheus discovers all future service


### PR DESCRIPTION
There is an indentation typo, which makes the configuration not usable.

Which other branches should this be merged with (if any)?

Please merge to 1.20 and 1.21.