### PR TITLE
Add known Ruby buildpack issue to release notes for 1.21

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -113,6 +113,8 @@ Maintenance change in this release:
 * **Updated RabbitMQ to v3.8.16:** For more information, see
 [RabbitMQ 3.8.16](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16) in GitHub.
 
+### Resolved Issues
+* This version fixes incompatibility with Ruby buildpack 1.8.33 and above.
 
 ### Known Issues
 
@@ -227,6 +229,7 @@ This release has the following fixes:
 This release has the following issue:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+* This release is incompatible with Ruby buildpack 1.8.33 and above. Upgrades to this version of <%= vars.product_short %> will fail the smoke test errand. This is fixed in v1.21.3.
 * This release does not contain the fix to [CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465).
 VMware recommends upgrading to v1.21.4 or later.
 
@@ -331,6 +334,7 @@ This release has the following issues:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
 <%= partial vars.path_to_partials + "/rabbitmq/ki-direct-reply-to" %>
+* This release is incompatible with Ruby buildpack 1.8.33 and above. Upgrades to this version of <%= vars.product_short %> will fail the smoke test errand. This is fixed in v1.21.3.
 * This release does not contain the fix to [CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465).
 VMware recommends upgrading to v1.21.4 or later.
 
@@ -467,6 +471,7 @@ This release has the following issues:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
 <%= partial vars.path_to_partials + "/rabbitmq/ki-direct-reply-to" %>
+* This release is incompatible with Ruby buildpack 1.8.33 and above. Upgrades to this version of <%= vars.product_short %> will fail the smoke test errand. This is fixed in v1.21.3.
 * This release does not contain the fix to [CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465).
 VMware recommends upgrading to v1.21.4 or later.
 


### PR DESCRIPTION
This can be made live whenever is convenient. The bug was present in versions 1.21.2 and lower, and was fixed in 1.21.3.