### PR TITLE
Add known Ruby buildpack issue to release notes for 2.0

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -116,6 +116,8 @@ Maintenance change in this release:
 * **Updated RabbitMQ to v3.8.16:** For more information, see
 [RabbitMQ 3.8.16](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.16) in GitHub.
 
+### Resolved Issues
+* This version fixes incompatibility with Ruby buildpack 1.8.33 and above.
 
 ### Known Issues
 
@@ -253,6 +255,7 @@ For more information, see
 This release has the following issues:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+* This release is incompatible with Ruby buildpack 1.8.33 and above. Upgrades to this version of <%= vars.product_short %> will fail the smoke test errand. This is fixed in v2.0.1.
 * This release does not contain the fix to [CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465).
 VMware recommends upgrading to v2.0.2 or later.
 


### PR DESCRIPTION
This can be made live whenever is convenient. The bug was present in version 2.0.0, and was fixed in 2.0.1.