### PR TITLE
Metrics names change when ugprading to 2.0

### DIFF
--- a/monitor.html.md.erb
+++ b/monitor.html.md.erb
@@ -14,6 +14,13 @@ pre-provisioned <%= vars.product_short %> service components.
 For information about metrics for the pre-provisioned service,
 see [Monitoring and KPIs for Pre‑Provisioned <%= vars.product_full %>](./monitor-pp.html).
 
+As of <%= vars.product_short %> v2.0, RabbitMQ Server metrics are now provided by the `rabbitmq_prometheus` plugin.
+Consequently, many metric names will change when upgrading to <%= vars.product_short %> v2.0.
+Both On-Demand <%= vars.product_short %> and Pre-Provisioned <%= vars.product_short %> are affected by this.
+For the full list of metrics that are emitted, see the
+[rabbitmq-server](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/metrics.md)
+repository in Github.
+
 <%# , but with the prefix `p.rabbitmq` instead of `p-rabbitmq`. %>
 
 <p class="note">


### PR DESCRIPTION
Hello, 

There will be a follow up PR to this one, to address some of the other issues here, 

https://github.com/pivotal-cf/docs-rabbitmq-pcf/issues/611

Thanks!

Alex 
