### PR TITLE
Add release notes for 2.0.6

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -5,100 +5,89 @@ owner: London Services
 
 <%= partial vars.path_to_partials + '/upgrade-planner' %>
 
-## <a id="2-0-x"></a> v2.0.x
+## <a id="2-0-6"></a> v2.0.6
 
-**Release Date**: DD MM, YYYY
+**Release Date**: September 21, 2021
 
-### Features
+### Resolved Issues
 
-New features and changes in this release:
-
-* **Run-in header:** Feature description.
-
-### Known Issues
-
-This release has the following issues:
-
-<%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+* Fixed an issue where logs from the Management UI where not getting deleted after some time. This eventually lead to running out of disk space
+* Configuring the prometheus endpoint to use TLs broke the prom_scraper job, this release resolves this issue.
 
 ### Compatibility
 
 The following components are compatible with this release:
 
-<table class="nice">
-  <th>Component</th>
-  <th>Version</th>
-  <tr>
-    <td>Erlang</td>
-    <td>23.2.7</td>
-  </tr>
-  <tr>
-    <td>HAProxy</td>
-    <td>1.8.29</td>
-  </tr>
-  <tr>
-    <td>OSS RabbitMQ<sup>*</sup></td>
-    <td>3.8.14</td>
-  </tr>
-  <tr>
-    <td>Stemcell</td>
-    <td>621.x</td>
-  </tr>
-  <tr>
-    <td><%= vars.app_runtime_full%></td>
-    <td>2.7.x, 2.8.x, 2.9.x, 2.10.x, and 2.11.x</td>
-  </tr>
-  <tr>
-    <td>bpm</td>
-    <td>1.1.9</td>
-  </tr>
-  <tr>
-    <td>cf-cli</td>
-    <td>1.32.0</td>
-  </tr>
-  <tr>
-    <td>cf-rabbitmq</td>
-    <td>366.0.0</td>
-  </tr>
-  <tr>
-    <td>cf-rabbitmq-multitenant-broker</td>
-    <td>93.0.0</td>
-  </tr>
-  <tr>
-    <td>cf-service-gateway</td>
-    <td>48.0.0</td>
-  </tr>
-  <tr>
-    <td>cf-rabbitmq-smoke-tests</td>
-    <td>94.0.0</td>
-  </tr>
-  <tr>
-    <td>loggregator-agent</td>
-    <td>6.2.0</td>
-  </tr>
-  <tr>
-    <td>on-demand-service-broker</td>
-    <td>0.40.0</td>
-  </tr>
-  <tr>
-    <td>rabbitmq-metrics</td>
-    <td>55.0.0</td>
-  </tr>
-  <tr>
-    <td>rabbitmq-on-demand-adapter</td>
-    <td>174.0.0</td>
-  </tr>
-  <tr>
-    <td>routing</td>
-    <td>0.213.0</td>
-  </tr>
-  <tr>
-    <td>service-metrics</td>
-    <td>2.0.13</td>
-  </tr>
-</table>
+<table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
+		<td><%= vars.app_runtime_full %></td>
+		<td>2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x</td>
+	</tr>
+	<tr>
+		<td>Erlang</td>
+		<td>23.3.4.6</td>
+	</tr>
+	<tr>
+		<td>HAProxy</td>
+		<td>1.8.30</td>
+	</tr>
+	<tr>
+		<td>OSS RabbitMQ*</td>
+		<td>3.8.22</td>
+	</tr>
+	<tr>
+		<td>Stemcell</td>
+		<td>621.x</td>
+	</tr>
+	<tr>
+		<td>bpm</td>
+		<td>1.1.13</td>
+	</tr>
+	<tr>
+		<td>cf-cli</td>
+		<td>1.33.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq</td>
+		<td>388.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-multitenant-broker</td>
+		<td>101.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-smoke-tests</td>
+		<td>106.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-service-gateway</td>
+		<td>55.0.0</td>
+	</tr>
+	<tr>
+		<td>loggregator-agent</td>
+		<td>6.3.4</td>
+	</tr>
+	<tr>
+		<td>on-demand-service-broker</td>
+		<td>0.42.1</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-metrics</td>
+		<td>62.0.0</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-on-demand-adapter</td>
+		<td>185.0.0</td>
+	</tr>
+	<tr>
+		<td>routing</td>
+		<td>0.223.0</td>
+	</tr>
+	<tr>
+		<td>service-metrics</td>
+		<td>2.0.14</td>
+	</tr>\n</table>
 
-<sup>*</sup> For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.14">v3.8.14</a> GitHub documentation.
+<sup>*</sup> For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.22">v3.8.22</a> GitHub documentation.
 
 ## <a id="view"></a> View Release Notes for Another Version
 


### PR DESCRIPTION
Hey Docs team, I wasn't sure weather I should open this PR against master or 2.0. Opening it against 2.0 cause a whole bunch of conflicts. 

Please can this be merged with the 2.0 branch. The target releae date for this patch is 21 September 2021

Do let me know if I can present these changes in a more compatible way. 

Thanks

* Alex
