### PR TITLE
Add note that metrics are aggregated in v2

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -531,6 +531,8 @@ Breaking changes in this release:
 * **RabbitMQ Server Metrics**: RabbitMQ Server metrics for both pre-provisioned and on-demand are
 now served using the `rabbitmq_prometheus` plugin. This changes the metrics emitted by the RabbitMQ
 Server component.
+In <%= vars.product_short %> v1.x, queue depth and queue consumer metrics were emitted for every queue.
+In <%= vars.product_short %> v2.0, queue metrics are [aggregated](https://www.rabbitmq.com/prometheus.html#metric-aggregation) by default.
 For more information about the plugin, see [Prometheus Plugin](monitor.html#prometheus).
 For the full list of metrics now emitted, see the
 [rabbitmq-server](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/metrics.md)


### PR DESCRIPTION
since is wasn't clear enough from the release notes.

In tile v1 https://github.com/pivotal-cf/rabbitmq-metrics-release
was used to query metrics from the RabbitMQ Management API.
This includes the queue depth (MessagesReady + MessagesUnacknowledged) of every queue.
See https://github.com/pivotal-cf/rabbitmq-metrics-release/blob/c137bc89e250d7e97b14c5b6bd544fb7aa565e19/src/rabbitmq-metrics/provider/api.go#L311-L327

In tile v2 Prometheus is used to query metrics.
By default, only aggregated metrics are returned.
See https://www.rabbitmq.com/prometheus.html#metric-aggregation.
To enable per queue metrics in tile v2, set prometheus.return_per_object_metrics = true.

Which other branches should this be merged with (if any)?
None