### PR TITLE
Add warning about mTLS in pre-provisioned

### DIFF
--- a/install-config-pp.html.md.erb
+++ b/install-config-pp.html.md.erb
@@ -248,6 +248,15 @@ certificates and keys for the RabbitMQ cluster to use.<br>
 1. To enable support for mTLS, select **Enable 'verify_peer' SSL certificate verification**.
 1. To enforce mTLS, additionally select **Require peer certificate validation**.
 
+<p class='note warning'>
+  <strong>Warning:</strong>
+  If enforcing mTLS, the smoke test errand will fail by default. This is because the certificate presented by the smoke test app
+  will not be trusted by your RabbitMQ instance. It is <strong>necessary</strong> to configure your RabbitMQ instace to trust the certificates
+  of the CAs which signed the smoke test app certificate.
+
+  These CAs' certificates can be located in Credhub. You will need to add both the `diego-instance-identity-root-ca-*` `diego-instance-identity-intermediate-ca-*`
+  to the trust store in the 'RabbitMQ server CA certificate(s)' section.
+</p>
 
 ### <a id="tls"></a>Configure TLS Support
 


### PR DESCRIPTION
In the future v2.0.7 release, we will fix a bug where smoke tests fail if mTLS is enabled. After this release, it will be possible to run smoke tests with mTLS, after adding a small amount of configuration.

This PR adds in the information into the TLS page about how to add this configuration. Another PR will do the same to the 2.0 branch, as well as adding in a 'Known Issue' for this bug into the previous 2.0 patches.