### PR TITLE
Update release notes for 2.0.9

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -55,7 +55,7 @@ The following components are compatible with this release:
   </tr>
   <tr>
     <td>OSS RabbitMQ*</td>
-    <td>3.8.26, 3.9.11</td>
+    <td>3.8.27, 3.9.12</td>
   </tr>
   <tr>
     <td>Stemcell</td>
@@ -67,11 +67,11 @@ The following components are compatible with this release:
   </tr>
   <tr>
     <td>cf-cli</td>
-    <td>1.35.0</td>
+    <td>1.36.0</td>
   </tr>
   <tr>
     <td>cf-rabbitmq</td>
-    <td>411.0.0</td>
+    <td>413.0.0</td>
   </tr>
   <tr>
     <td>cf-rabbitmq-multitenant-broker</td>
@@ -112,8 +112,8 @@ The following components are compatible with this release:
 </table>
 
 <sup>*</sup>For more information, see the
-<a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.26">v3.8.26</a> and
-<a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.11">v3.9.11</a> GitHub documentation.
+<a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.8.27">v3.8.27</a> and
+<a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.12">v3.9.12</a> GitHub documentation.
 
 ## <a id="2-0-8"></a> v2.0.8
 


### PR DESCRIPTION
We had to bump some dependencies before the actual release. These new release notes match the latest build to be promoted to a release.

Which other branches should this be merged with (if any)?
No need to merge to other branches.
