### PR TITLE
Add 2.0.13 release notes, including known issue.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -19,6 +19,99 @@ owner: London Services
 
 <%= partial vars.path_to_partials + '/services/services-lts-notice', :locals => {:eogs_date => "April 2024"} %>
 
+## <a id="2-0-13"></a> v2.0.13
+
+**Release Date**: April 29, 2022
+
+### Resolved Issues
+
+This release fixes the following issues:
+
+- **TLS can prevent metric exporting:** Metrics can't be exported to the Firehose when TLS is enabled.
+- **TLS can prevent metric scraping:** Healthwatch v2 can't scrape metrics from on-demand instances when TLS is enabled.
+- **RAFT log crash can cause Quourm Queues to crash:** Should a RAFT log process crash and a quorurm queue member attempt to write to the log while down, the quourum queue will also crash, causing unavailability.
+
+
+### Known Issues
+
+This release has the following known issues:
+
+
+### Compatibility
+
+The following components are compatible with this release:
+
+<table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
+		<td><%= vars.app_runtime_full %></td>
+		<td>2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x, 2.12.x</td>
+	</tr>
+	<tr>
+		<td>Erlang</td>
+		<td>24.3.3</td>
+	</tr>
+	<tr>
+		<td>HAProxy</td>
+		<td>1.8.30</td>
+	</tr>
+	<tr>
+		<td>OSS RabbitMQ*</td>
+		<td>3.8.29, 3.9.15</td>
+	</tr>
+	<tr>
+		<td>Stemcell</td>
+		<td>621.x</td>
+	</tr>
+	<tr>
+		<td>bpm</td>
+		<td>1.1.16</td>
+	</tr>
+	<tr>
+		<td>cf-cli</td>
+		<td>1.38.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq</td>
+		<td>433.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-multitenant-broker</td>
+		<td>114.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-rabbitmq-smoke-tests</td>
+		<td>128.0.0</td>
+	</tr>
+	<tr>
+		<td>cf-service-gateway</td>
+		<td>71.0.0</td>
+	</tr>
+	<tr>
+		<td>loggregator-agent</td>
+		<td>6.3.11</td>
+	</tr>
+	<tr>
+		<td>on-demand-service-broker</td>
+		<td>0.42.4</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-metrics</td>
+		<td>77.0.0</td>
+	</tr>
+	<tr>
+		<td>rabbitmq-on-demand-adapter</td>
+		<td>207.0.0</td>
+	</tr>
+	<tr>
+		<td>routing</td>
+		<td>0.231.0</td>
+	</tr>
+	<tr>
+		<td>service-metrics</td>
+		<td>2.0.15</td>
+	</tr>\n</table>
+
+<sup>*</sup> For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v">v</a> GitHub documentation.
+
 ## <a id="2-0-12"></a> v2.0.12
 
 **Release Date**: MONTH DAY, 2022
@@ -37,6 +130,7 @@ This release has the following known issues:
 
 - **TLS can prevent metric exporting:** Metrics can't be exported to the Firehose when TLS is enabled.
 - **TLS can prevent metric scraping:** Healthwatch v2 can't scrape metrics from on-demand instances when TLS is enabled.
+- **RAFT log crash can cause Quourm Queues to crash:** Should a RAFT log process crash and a quorurm queue member attempt to write to the log while down, the quourum queue will also crash, causing unavailability.
 
 
 ### Compatibility


### PR DESCRIPTION
Hi docs team!

Here's a PR for 2.0.13 release notes. 

For more context on the RAFT crash, see https://github.com/rabbitmq/rabbitmq-server/issues/4512 and the related PR https://github.com/rabbitmq/ra/pull/271
