### PR TITLE
Fix supported TAS versions for 2.0.x patches

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -44,7 +44,7 @@ The following components are compatible with this release:
   <th>Version</th>
   <tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x</td>
+		<td>2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x, 2.12.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>
@@ -142,7 +142,7 @@ The following components are compatible with this release:
   <th>Version</th>
   <tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x</td>
+		<td>2.7.x, 2.8.x, 2.9.x, 2.10.x, 2.11.x, 2.12.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>


### PR DESCRIPTION
For some reason they were listing the wrong set of supported versions.

Which other branches should this be merged with (if any)? None
