### PR TITLE
Add known issue for missing syslog drain certificate.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -24,6 +24,7 @@ New features and changes in this release:
 This release has the following issues:
 
 <%= partial vars.path_to_partials + "/rabbitmq/erlang-ki" %>
+* Logs may fail to be collected by the loggregator subsystem due to a missing certificate.
 
 ### Resolved Issues
 


### PR DESCRIPTION
Which other branches should this be merged with (if any)?

This issue also impacts tile 2.1. 

We will be releasing an upcoming patch to tile 2.2 and 2.1 to resolve this issue.
