### PR TITLE
Fix release note version table.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -161,7 +161,7 @@ The following components are compatible with this release:
 	</tr>
 	<tr>
 		<td>OSS RabbitMQ*</td>
-		<td>3.9.22, 3.10.7</td>
+		<td>3.9.24, 3.10.10</td>
 	</tr>
 	<tr>
 		<td>Stemcell</td>
@@ -177,7 +177,7 @@ The following components are compatible with this release:
 	</tr>
 	<tr>
 		<td>cf-rabbitmq</td>
-		<td>464.0.0</td>
+		<td>465.0.0</td>
 	</tr>
 	<tr>
 		<td>cf-rabbitmq-multitenant-broker</td>


### PR DESCRIPTION
The release notes for v2.1.5 contained incorrect versions. This contains the correction.
