### PR TITLE
Require TAS 2.11.16+ due to ruby buildpack support compatibility.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -30,7 +30,7 @@ The following components are compatible with this release:
 
 <table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x</td>
+		<td>2.11.16+, 2.12.x, 2.13.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>
@@ -132,7 +132,7 @@ The following components are compatible with this release:
 <table class="nice"> <th>Component</th> <th>Version</th>
 	<tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x</td>
+		<td>2.11.16+, 2.12.x, 2.13.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>
@@ -226,7 +226,7 @@ The following components are compatible with this release:
 
 <table class="nice"> <th>Component</th> <th>Version</th> 	<tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x</td>
+		<td>2.11.16+, 2.12.x, 2.13.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>


### PR DESCRIPTION
In order to ensure compatibility with recent TAS patches, the smoke test app has been upgraded to Ruby ~3.1. This requires a recent ruby-buildpack.

