### PR TITLE
Add requirement for TAS 2.11.16+ due to ruby-buildpack requirement.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -36,7 +36,7 @@ The following components are compatible with this release:
 <table class="nice"> <th>Component</th> <th>Version</th>
   <tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x, 3.0.x, 4.0.x</td>
+		<td>2.11.16+, 2.12.x, 2.13.x, 3.0.x, 4.0.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>
@@ -137,7 +137,7 @@ The following components are compatible with this release:
 <table class="nice"> <th>Component</th> <th>Version</th>
 	<tr>
 		<td><%= vars.app_runtime_full %></td>
-		<td>2.11.x, 2.12.x, 2.13.x, 3.0.x, 4.0.x</td>
+		<td>2.11.16+, 2.12.x, 2.13.x, 3.0.x, 4.0.x</td>
 	</tr>
 	<tr>
 		<td>Erlang</td>
@@ -233,7 +233,7 @@ The following components are compatible with this release:
 <th>Version</th>
   <tr>
     <td><%= vars.app_runtime_full %></td>
-    <td>2.11.x, 2.12.x, 2.13.x, 3.0.x</td>
+    <td>2.11.16+, 2.12.x, 2.13.x, 3.0.x</td>
   </tr>
   <tr>
     <td>Erlang</td>


### PR DESCRIPTION
In order to guarantee compatibility with newer versions of TAS, the smoke-test app has been upgraded to use Ruby ~3.1. Therefore, a sufficiently recent version of the ruby buildpack is required.

