### PR TITLE
Include missing compatibility matrix.

### DIFF
--- a/releases.html.md.erb
+++ b/releases.html.md.erb
@@ -512,6 +512,86 @@ This release fixes the following issues:
 - Deployments with metrics polling interval set to `-1` failing.
   [loggregator-agent-release v6.5.6](https://github.com/cloudfoundry/loggregator-agent-release/releases/tag/v6.5.6) fixes this.
 
+## Compatibility
+
+The following components are compatible with this release:
+
+<table class="nice">
+  <th>Component</th>
+  <th>Version</th>
+  <tr>
+    <td><%= vars.app_runtime_full %></td>
+    <td>2.11.x, 2.12.x, 2.13.x</td>
+  </tr>
+  <tr>
+    <td>Erlang</td>
+    <td>24.3.4.7, 25.2</td>
+  </tr>
+  <tr>
+    <td>HAProxy</td>
+    <td>2.6.7</td>
+  </tr>
+  <tr>
+    <td>OSS RabbitMQ<sup>*</sup></td>
+    <td>3.9.27, 3.10.13</td>
+  </tr>
+  <tr>
+    <td>Stemcell</td>
+    <td>621.x</td>
+  </tr>
+  <tr>
+    <td>bpm</td>
+    <td>1.1.21</td>
+  </tr>
+  <tr>
+    <td>cf-cli</td>
+    <td>1.41.0</td>
+  </tr>
+  <tr>
+    <td>cf-rabbitmq</td>
+    <td>478.0.0</td>
+  </tr>
+  <tr>
+    <td>cf-rabbitmq-multitenant-broker</td>
+    <td>128.0.0</td>
+  </tr>
+  <tr>
+    <td>cf-service-gateway</td>
+    <td>91.0.0</td>
+  </tr>
+  <tr>
+    <td>cf-rabbitmq-smoke-tests</td>
+    <td>154.0.0</td>
+  </tr>
+  <tr>
+    <td>loggregator-agent</td>
+    <td>7.0.1</td>
+  </tr>
+  <tr>
+    <td>on-demand-service-broker</td>
+    <td>0.42.6</td>
+  </tr>
+  <tr>
+    <td>rabbitmq-metrics</td>
+    <td>96.0.0</td>
+  </tr>
+  <tr>
+    <td>rabbitmq-on-demand-adapter</td>
+    <td>227.0.0</td>
+  </tr>
+  <tr>
+    <td>routing</td>
+    <td>0.254.0</td>
+  </tr>
+  <tr>
+    <td>service-metrics</td>
+    <td>2.0.24</td>
+  </tr>
+</table>
+
+<sup>*</sup> For more information, see the <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.9.27">v3.9.27</a> and <a href="https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.10.13">v3.10.13</a> GitHub documentation.
+
+
 ## <a id="2-1-5"></a> v2.1.5
 
 **Release Date**: November 10, 2022


### PR DESCRIPTION
Somehow the compatibility matrix didn't get included in the 2.1.6 release notes. Here's a PR to fix this. Thanks!
