### PR TITLE
Remove references to Log Cache Nozzle ingestion (2.3)

### DIFF
--- a/troubleshoot-instances.html.md.erb
+++ b/troubleshoot-instances.html.md.erb
@@ -6,19 +6,6 @@ owner: London Services
 This topic for app developers gives you basic instructions for troubleshooting on-demand
 <%= vars.product_full %> service instances.
 
-## <a id="errors"></a> Troubleshoot Errors
-
-Start here if you are responding to a specific error or error messages.
-
-### <a id="common-errors"></a> Common Service Errors
-
-The following errors occur in multiple services:
-
-<%# The below partial is in https://github.com/pivotal-cf/docs-partials %>
-
-<%= partial vars.path_to_partials + '/services-tshoot/tshoot-no-metrics' %>
-
-
 ## <a id="techniques"></a> Techniques for Troubleshooting
 
 See the following sections for troubleshooting techniques when using


### PR DESCRIPTION
- RabbitMQ for VMs 2.3 is compatible with TAS 3.0+.
- TAS 3.0 removed the ability to configure Log Cache for nozzle ingestion